### PR TITLE
First impl of "scatter"/events in reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the "dlt-logs" extension will be documented in this file.
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
+## [0.29.0]
+
+- Added "EVENT_" / event/scatter reports using single dots and not lines in the reports. See issue/feature request #3.
 
 ## [0.28.1]
 - Updated readme to point to the new [Docs](https://mbehr1.github.io/dlt-logs/) containing more info for reports (currently).

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This extension contributes the following settings:
    * **negative**: if filter matches the message will not be included in the view.
    * **marker**: if filter matches the messages will be "marked"/decorated.
    * **event**: used for time-sync event detection or for report generation. For reports the payloadRegex must be used and capture data. If the capture group name starts with "STATE_" distinct/"state"/"level" values are assumed. If the capture group name starts with "INT_" the value is parsed as integer and can e.g be in hex (0x...). Otherwise linear (float-)values. By default report filters are added into the last active report window. If you want to add another report window use the "alt/option".
+   If the capture group name starts with "EVENT_" the data is drawn using scatter/dot-based charts and not using line-based ones.
 
    Currently filter can match for:
    * **ecu**: the ECU identifier.

--- a/docs/dlt-logs/docs/reports.md
+++ b/docs/dlt-logs/docs/reports.md
@@ -58,8 +58,17 @@ By default all captures needs will be parsed as float numbers. You can change th
 value name | excected type | comment
 ---------- | ------------- | -------
 STATE_* | enum | Used to represent distinct states. Will use 2nd axix. Can be ints or strings. See reportOptions/valueMap on how to map to better readable names.
+EVENT_* | float | will use scatter/event - dot based and not line based chart.
 INT_* | int | will use parseInt(). Can be used if e.g. hex values should be converted.
 other | float | will use parseFloat().
+
+:::note
+STATE_ and EVENT_ logically exclude each other as you do either want to draw a state diagram or a scatter/point diagram. But INT_ logically would fit as well for STATE_ or EVENT_ but this can't be encoded using the value name. So e.g. if you need to convert hex values this is possible using a **conversionFunction** that converts the value already. E.g. 
+
+```json
+return { 'STATE_foo': Number.parseInt(matches[1])};
+```
+:::
 
 Grid lines for lifecycle start/ends are automatically added. 
 

--- a/media/timeSeriesReport.html
+++ b/media/timeSeriesReport.html
@@ -226,6 +226,7 @@
 
                             if (i >= config.data.datasets.length) {
                                 config.data.datasets.push({ // todo check for multiple yLabels
+                                    type: ('type' in message.data[i]) ? message.data[i].type : 'line',
                                     label: message.data[i].label,
                                     data: message.data[i].dataYLabels.data,
                                     fill: false,
@@ -236,6 +237,7 @@
 
                             if (i < config.data.datasets.length) {
                                 config.data.datasets[i].label = message.data[i].label;
+                                config.data.datasets[i].type = ('type' in message.data[i]) ? message.data[i].type : 'line';
                                 if (message.data[i].dataYLabels.yLabels !== undefined) {
                                     vscode.postMessage({ message: 'update config.data.yLabels=' + config.data.yLabels + ' with ' + message.data[i].dataYLabels.yLabels });
                                     const dsi = config.data.datasets[i];

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "dlt-logs",
 	"displayName": "DLT-Logs",
 	"description": "Open DLT diagnostic log and trace files with lifecycle detection, filters, time-sync, etc.",
-	"version": "0.28.1",
+	"version": "0.29.0",
 	"license": "CC-BY-NC-SA-4.0",
 	"publisher": "mbehr1",
 	"author": {

--- a/src/dltReport.ts
+++ b/src/dltReport.ts
@@ -393,7 +393,7 @@ export class DltReport implements vscode.Disposable {
                     });
                 }
 
-                datasetArray.push({ label: label, dataYLabels: data });
+                datasetArray.push({ label: label, dataYLabels: data, type: label.startsWith('EVENT_') ? 'scatter' : 'line' });
             });
 
             this.postMsgOnceAlive({ command: "update", data: datasetArray });


### PR DESCRIPTION
If captured or converted data starts with "EVENT_" it will be drawn
as a "scatter"/event chart. So not using lines but single dots.
This works only for "float" values (yet).

Resolves: #3