### PR TITLE
Support an optional second y-axis for datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ This extension contributes the following settings:
      * **conversionFunction**: can be used to modify the captured values for that event. Needs to be a JS function returning an array of objects { valueName: value } gets the regex 'matches' as parameter. Additional parameter is "params" which is an object with msg, localObj and reportObj. TODO create wiki with full example. E.g. "return {'limit':42};" for a static value. or "return {'timeStamp': params.msg.timeStamp/10000};". 'localObj' is initially an empty Object {} that can be used to store properties for that filter (e.g. interims data for calculations).  'reportObj' is an Object similar to localObj but shared between all filters. So take care here for name clashes!
      * **valueMap**: object that can contain keys matching to the captured data names and the property is an array with objects { capturedName : newName }. 
      E.g."reportOptions": { "valueMap": { "STATE_onOff": [ { "1": "on" }, { "0": "off" }, {"ff": "invalid" }]}}
+     * **axisMap**: object that can contain keys matching to the captured data names and the property is an ID of the y-axis (0 = left, 1 = right) the captured data should belong to. 
+     E.g."reportOptions": { "axisMap": { "temperature": 1, "speed", 0 }}
 
    Filter configuration changes and menu items *add filter...*, *edit filter...*, *delete filter...* actions will be applied instantly to the configuration/view.
 

--- a/media/timeSeriesReport.html
+++ b/media/timeSeriesReport.html
@@ -106,6 +106,7 @@
                     borderWidth: 1,
                     pointRadius: 2,
                     fill: false,
+                    yAxisGroup: 0,
                     data: []
                 }]
             },
@@ -141,12 +142,20 @@
                         }
                     },
                     {
-                        id: 'y-axis-1',
+                        id: 'y-axis-cat',
                         display: 'auto',
                         type: 'category',
                         ticks: {
                             reverse: true
                         }
+                    },{
+                        id: 'y-axis-1',
+                        display: 'auto',
+                        scaleLabel: {
+                            display: true,
+                            labelString: 'values'
+                        },
+                        position: 'right'
                     }]
                 },
                 animation: { duration: 0 },
@@ -241,7 +250,7 @@
                                 if (message.data[i].dataYLabels.yLabels !== undefined) {
                                     vscode.postMessage({ message: 'update config.data.yLabels=' + config.data.yLabels + ' with ' + message.data[i].dataYLabels.yLabels });
                                     const dsi = config.data.datasets[i];
-                                    config.data.datasets[i].yAxisID = config.options.scales.yAxes[1].id; // 'y-axis-1'; // todo try multiple y-axis and no merge of labels (but e.g. ' ' to fill gaps)
+                                    config.data.datasets[i].yAxisID = config.options.scales.yAxes[1].id; // 'y-axis-cat'; // todo try multiple y-axis and no merge of labels (but e.g. ' ' to fill gaps)
                                     config.data.datasets[i].lineTension = 0;
                                     for (let j = 0; j < message.data[i].dataYLabels.yLabels.length; ++j) {
                                         if (!(config.options.scales.yAxes[1].labels.includes(message.data[i].dataYLabels.yLabels[j])))
@@ -249,7 +258,8 @@
                                     }
                                     //vscode.postMessage({ message: 'config.options.scales=' + JSON.stringify(config.options.scales, null, 2) });
                                 } else {
-                                    config.data.datasets[i].yAxisID = config.options.scales.yAxes[0].id; // 'y-axis-0';
+                                    config.data.datasets[i].yAxisID = 'y-axis-' + message.data[i].dataYLabels.yAxisGroup;
+                                    vscode.postMessage({ message: 'axis used for ' + message.data[i].label + '=' + config.data.datasets[i].yAxisID });
                                     config.data.datasets[i].lineTension = 0.4;
                                 }
                                 config.data.datasets[i].data = message.data[i].dataYLabels.data;

--- a/package.json
+++ b/package.json
@@ -244,6 +244,10 @@
 											"type": "object",
 											"description": "See todo for details."
 										},
+										"axisMap": {
+											"type": "object",
+											"description": "y-axis ID for a dataset label"
+										},
 										"conversionFunction": {
 											"type": "string",
 											"description": "Javascript function body as string. See todo for details."

--- a/src/dltReport.ts
+++ b/src/dltReport.ts
@@ -139,7 +139,7 @@ export class DltReport implements vscode.Disposable {
         const lcEndDate: Date = lcDates[lcDates.length - 1];
         console.log(`updateReport lcStartDate=${lcStartDate}, lcEndDate=${lcEndDate}`);
 
-        let dataSets = new Map<string, { data: { x: Date, y: string | number, lcId: number }[], yLabels?: string[] }>();
+        let dataSets = new Map<string, { data: { x: Date, y: string | number, lcId: number }[], yLabels?: string[], yAxisGroup: number }>();
 
         let minDataPointTime: Date | undefined = undefined;
 
@@ -155,7 +155,7 @@ export class DltReport implements vscode.Disposable {
 
             const dataPoint = { x: time, y: value, lcId: lifecycle.uniqueId };
             if (!dataSet) {
-                dataSet = { data: [dataPoint] };
+                dataSet = { data: [dataPoint], yAxisGroup: 0 };
                 dataSets.set(label, dataSet);
                 lastDataPoints.set(label, dataPoint);
             } else {
@@ -186,7 +186,6 @@ export class DltReport implements vscode.Disposable {
 
 
             }
-
         };
 
         const msgs = this.doc.msgs;
@@ -316,6 +315,26 @@ export class DltReport implements vscode.Disposable {
                                 } else {
                                     console.log(`   dataSet got no yLabels?`);
                                 }
+                            }
+                        }));
+                    }
+                    if ('axisMap' in filter.reportOptions) {
+                        /*
+                        For axisMap we do expect an object where the keys/properties match to the dataset name
+                        and the property values are IDs for the axis to use for that dataset
+                        "axisMap":{
+                            "temp_x": 1, // use y-axis 1 for dataset with label 'temp_x'
+                            "speed_y": 0 // use y-axis 0 for dataset with label 'speed_y' (this is the default when not defined)
+                        }
+                         */
+                        const axisMap = filter.reportOptions.axisMap;
+                        Object.keys(axisMap).forEach(((value) => {
+                            console.log(` got axisMap.${value} : ${axisMap[value]}`);
+                            // do we have a dataSet with that label?
+                            const dataSet = dataSets.get(value);
+                            if (dataSet) {
+                                const axisId: number = axisMap[value];
+                                dataSet.yAxisGroup = axisId;
                             }
                         }));
                     }


### PR DESCRIPTION
This serves as a basis for discussion/improvement, there are probably lot's of possible tweaks to support such a feature.
Feel free to take this and modify as you wish.

With this change you can define the "yAxisGroup" property in a filter config and set it to 0 (left y-axis) or 1 (right y-axis).
```
{
	"name": "Test",
	"type": 3,
	"apid": "TEST",
	"ctid": "CTX",
	"payloadRegex": "^Hello (?<world>\w+)",
	"yAxisGroup": 1
}
```