### PR TITLE
feat: add mtin string to restquery results for msgs

### DIFF
--- a/src/dltParser.ts
+++ b/src/dltParser.ts
@@ -191,6 +191,7 @@ export class DltMsg {
                 mcnt: this.mcnt,
                 apid: this.apid,
                 ctid: this.ctid,
+                mtin: MTIN_LOG_strs[this.mtin],
                 payloadString: this.payloadString,
                 lifecycle: this.lifecycle ? this.lifecycle.persistentId : undefined
             }


### PR DESCRIPTION
This change adds the mtin info string to the rest query result (e.g. info, warning, error, etc.).