### PR TITLE
feat(adlt): add path to adlt to terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A more detailed documentation is available here: [Docs](https://mbehr1.github.io
   - supports opening multiple files at once
   - supports opening of CAN .asc files (simply choose the .asc file instead of .dlt files during "Open DLT file via adlt..." command)
   - supports all plugins except file-transfer. Additionally a 'CAN' plugin is available.
+  - an adlt binary is provided with the extension and the path to it is available in VS code terminals or via command "New terminal with adlt in path".
 - **Time sync** feature.
   - Calculates time for each line based on timestamp and reception/storage time.
   - An offset for the full time can be set via context menu item *adjust-time...*.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 		"onFileSystem:adlt-log",
 		"onCommand:dlt-logs.dltOpenFile",
 		"onCommand:dlt-logs.dltOpenAdltFile",
-		"onCommand:dlt-logs.dltExportFile"
+		"onCommand:dlt-logs.dltExportFile",
+		"onCommand:dlt-logs.adltTerminal"
 	],
 	"capabilities": {
 		"virtualWorkspaces": false,
@@ -616,6 +617,10 @@
 			{
 				"command": "dlt-logs.dltOpenAdltFile",
 				"title": "Open DLT file via adlt..."
+			},
+			{
+				"command": "dlt-logs.adltTerminal",
+				"title": "New terminal with adlt in path"
 			},
 			{
 				"command": "dlt-logs.adjustTime",

--- a/src/adltDocumentProvider.ts
+++ b/src/adltDocumentProvider.ts
@@ -2087,6 +2087,14 @@ export class ADltDocumentProvider implements vscode.FileSystemProvider,
         this._adltCommand = vscode.workspace.getConfiguration().get<string>("dlt-logs.adltPath") || ((adltPath !== undefined && typeof adltPath === 'string') ? adltPath : "adlt");
         console.log(`adlt.ADltDocumentProvider using adltCommand='${this._adltCommand}'`);
 
+        if (adltPath !== undefined) {
+            // add it to env
+            let envCol = context.environmentVariableCollection;
+            const adltPathPath = path.dirname(adltPath);
+            console.log(`adlt updating env PATH with :'${adltPathPath}'`);
+            context.environmentVariableCollection.prepend('PATH', adltPathPath + path.delimiter);
+        }
+
         // config changes
         context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {
             if (e.affectsConfiguration('dlt-logs')) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,6 +188,13 @@ export function activate(context: vscode.ExtensionContext) {
 		);
 	}));
 
+	// register command to open a terminal with adlt:
+	context.subscriptions.push(vscode.commands.registerCommand('dlt-logs.adltTerminal', async () => {
+		// this is not really needed as the path of the shipped/contained adlt binary is anyhow added to env but
+		// only after the extension has been loaded. So using this command loads the extension.
+		vscode.window.createTerminal({ name: `adlt terminal`, message: `use e.g. 'adlt -h' to see help for adlt` }).show();
+	}));
+
 	// on change of active text editor update calculated decorations:
 	context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(async (activeTextEditor: vscode.TextEditor | undefined) => {
 		let hideStatusBar = true;


### PR DESCRIPTION
Added the path to the embedded adlt binary to the env PATH for embedded terminals.
Added command "New terminal with adlt in path" as well (a bit redundant
but ensure that the extension gets loaded first).