### PR TITLE
feat: add button 'set pos filter' to treeview

### DIFF
--- a/package.json
+++ b/package.json
@@ -681,6 +681,11 @@
 				"icon": "$(zoom-out)"
 			},
 			{
+				"command": "dlt-logs.setPosFilter",
+				"title": "set pos. filter",
+				"icon": "$(add)"
+			},
+			{
 				"command": "dlt-logs.openReport",
 				"title": "open report",
 				"icon": "$(graph)"
@@ -759,6 +764,11 @@
 				{
 					"command": "dlt-logs.zoomOut",
 					"when": "view == dltLifecycleExplorer && viewItem =~ /canZoomOut/",
+					"group": "inline"
+				},
+				{
+					"command": "dlt-logs.setPosFilter",
+					"when": "view == dltLifecycleExplorer && viewItem =~ /canSetPosF/",
 					"group": "inline"
 				}
 			],

--- a/src/adltDocumentProvider.ts
+++ b/src/adltDocumentProvider.ts
@@ -2225,6 +2225,7 @@ export class ADltDocumentProvider implements vscode.FileSystemProvider,
             case 'disableFilter': this.modifyNode(node, 'disable'); break;
             case 'zoomOut': this.modifyNode(node, 'zoomOut'); break;
             case 'zoomIn': this.modifyNode(node, 'zoomIn'); break;
+            case 'setPosFilter': this.modifyNode(node, 'setPosFilter'); break;
             default:
                 console.error(`adlt.onTreeNodeCommand unknown command '${command}'`); break;
         }

--- a/src/dltDocumentProvider.ts
+++ b/src/dltDocumentProvider.ts
@@ -297,6 +297,7 @@ export class DltDocumentProvider implements vscode.FileSystemProvider,
             case 'disableFilter': this.modifyNode(node, 'disable'); break;
             case 'zoomOut': this.modifyNode(node, 'zoomOut'); break;
             case 'zoomIn': this.modifyNode(node, 'zoomIn'); break;
+            case 'setPosFilter': this.modifyNode(node, 'setPosFilter'); break;
             default:
                 console.error(`dlt.onTreeNodeCommand unknown command '${command}'`); break;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -333,6 +333,10 @@ export function activate(context: vscode.ExtensionContext) {
 		adltProvider.onTreeNodeCommand('zoomOut', args[0]);
 	}));
 
+	context.subscriptions.push(vscode.commands.registerCommand('dlt-logs.setPosFilter', async (...args: any[]) => {
+		dltProvider.onTreeNodeCommand('setPosFilter', args[0]);
+		adltProvider.onTreeNodeCommand('setPosFilter', args[0]);
+	}));
 
 
 	context.subscriptions.push(vscode.commands.registerCommand('dlt-logs.openReport', async (...args: any[]) => {


### PR DESCRIPTION
Button is visible only when no pos. filters are set, so the apid/ctid is
visible. This helps to set a pos. filter only showing those and not
removing only those messages.