### PR TITLE
fix(adlt): ensure fileExtensions contain dlt and asc

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,7 +163,12 @@ export function activate(context: vscode.ExtensionContext) {
 	// register our command to open dlt files via adlt:
 	context.subscriptions.push(vscode.commands.registerCommand('dlt-logs.dltOpenAdltFile', async () => {
 		let file_exts = <Array<string>>(vscode.workspace.getConfiguration().get("dlt-logs.fileExtensions")) || [];
-		if (Array.isArray(file_exts)) { file_exts.push("asc"); }
+		if (Array.isArray(file_exts)) {
+			if (!file_exts.includes("dlt")) { file_exts.push("dlt"); }
+			if (!file_exts.includes("asc")) { file_exts.push("asc"); }
+		} else {
+			file_exts = ["dlt", "asc"];
+		}
 		console.log(`open dlt via adlt file_exts=${JSON.stringify(file_exts)}`);
 		return vscode.window.showOpenDialog({ canSelectFiles: true, canSelectFolders: false, canSelectMany: true, filters: { 'DLT Logs': file_exts }, openLabel: 'Select DLT file(s) to open...' }).then(
 			async (uris: vscode.Uri[] | undefined) => {


### PR DESCRIPTION
To provent users settings it e.g. by mistake to "" or empty array always
- check for array
- check that dlt and asc are included.