### PR TITLE
fix(config): plugins can be specified in any order

### DIFF
--- a/package.json
+++ b/package.json
@@ -305,7 +305,8 @@
 					},
 					"dlt-logs.plugins": {
 						"type": "array",
-						"items": [
+						"items": {
+							"oneOf": [
 							{
 								"type": "object",
 								"title": "FileTransfer plugin",
@@ -488,7 +489,8 @@
 									}
 								}
 							}
-						],
+						]
+					},
 						"default": [
 							{
 								"name": "FileTransfer",


### PR DESCRIPTION
Previously plugins needed to be specified in the
exact sequence. This was never intended.
Now any of them can be specified.
Leaving a race-condition/misuse if the same plugin is specified multiple
times.