### PR TITLE
docs: add extension asc to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -831,6 +831,12 @@
 					".dlt",
 					".DLT"
 				]
+			},
+			{
+				"id": "can-asc",
+				"extensions": [
+					".asc"
+				]
 			}
 		]
 	},


### PR DESCRIPTION
To let the marketplace know that we do support that as well.