### PR TITLE
feat(report): add quick report feature

### DIFF
--- a/src/generateRegex.ts
+++ b/src/generateRegex.ts
@@ -1,0 +1,114 @@
+/* --------------------
+ * Copyright(C) Matthias Behr. 2022
+ */
+
+/**
+ * generate a regex from a set of strings.
+ * Adds regex captures for
+ *   - numbers (float with decimal '.' e.g. -42.1) with capture group name 'NR_1..'
+ *   - words (single different words) with capture group name 'STATE_1..'
+ * 
+ * Example:
+ * 
+ *  ['-42.1bar middle baz', '17baz middle bar'] returns a regex with 3 capture groups:
+ * 
+ *  '^(?\<NR_1>)(?\<STATE_1>) middle (?\<STATE_2>)'.
+ * 
+ * Remark:
+ *  - currently differences are determined on word boundaries and not on patterns.
+ *   E.g. ['start one two end','start three end'] are not detected as
+ *  '^start (?\<STATE_1>) end'
+ *  - hex numbers are not detected/captured properly yet!
+ * @param toMatchArr array of strings that should be matched with the regex generated
+ * @returns array of regexp that do match the strings
+ */
+
+export function generateRegex(toMatchArr: string[]): RegExp[] {
+    if (toMatchArr.length === 0) { return []; }
+
+    // step 1: replace all numbers with special chars
+    const replNumber = '##NR##'; // TODO search string for non existance and add more chars until not exist
+    // must not contain parts that will be escaped!
+    // same for
+    const replWord = '##W##';
+
+    // todo add support for hex numbers
+    const regExNrFind = /(?<=^| )-?\d+(\.\d+)?/g; // nr at start of text or after a space ' '
+    const regExNrInsert = /(?<NR__>-?\d+(?:\.\d+)?)/;
+
+    const regExWordFind = /(\w+)/;
+    const regExWordInsert = /(?<W__>\w+)/;
+
+    // use a copy and dont modify orig strings
+    let toMatchArrCopy: string[] = [];
+    for (const toMatch of toMatchArr) {
+        const cpy = toMatch.replace(regExNrFind, replNumber);
+        toMatchArrCopy.push(cpy);
+    }
+
+    if (toMatchArrCopy.length > 1) {
+        // now that numbers are removed/similar - search for communalities:
+        let startIndex = 0;
+        let minStrLength = toMatchArrCopy.reduce((prev, cur) => Math.min(prev, cur.length), toMatchArrCopy[0].length);
+        while (startIndex < minStrLength) {
+            let prefix = longestCommonPrefix(startIndex, toMatchArrCopy);
+            console.log(`prefix(startIndex=${startIndex}, minStrLength=${minStrLength})='${prefix}'`);
+            // as we want word boundaries have a prefix end at a ' ' (or end of string)
+            let prefixLen = prefix.length;
+            if (prefixLen + startIndex >= minStrLength) { break; }
+            if (prefix.includes(' ')) {
+                prefix = prefix.slice(0, prefix.lastIndexOf(' ') + 1);
+                console.log(`prefix(startIndex=${startIndex}, minStrLength=${minStrLength}) using '${prefix}'`);
+                prefixLen = prefix.length;
+            } else {
+                const idxReplNumber = prefix.lastIndexOf(replNumber);
+                prefixLen = idxReplNumber < 0 ? 0 : idxReplNumber + replNumber.length;
+                console.log(`prefix(startIndex=${startIndex}, minStrLength=${minStrLength}) ignoring '${prefix}' using '${prefix.slice(0, prefixLen)}'`);
+            }
+            // use that prefix and a word regex
+            toMatchArrCopy = toMatchArrCopy.map((toMatch) => toMatch.slice(0, startIndex + prefixLen) +
+                toMatch.slice(startIndex + prefixLen).replace(regExWordFind, replWord));
+            console.log(`prefix(startIndex=${startIndex}, minStrLength=${minStrLength}) replaced '${toMatchArrCopy}'`);
+
+            // determine new start index
+            startIndex = startIndex + prefixLen + replWord.length;
+            minStrLength = toMatchArrCopy.reduce((prev, cur) => Math.min(prev, cur.length), toMatchArrCopy[0].length);
+        }
+    }
+
+    // now create a regex:
+    // a) escape all remaining chars
+    toMatchArrCopy = toMatchArrCopy.map((toMatch) => '^' + escapeRegExp(toMatch) + '$');
+
+    // b) replace the placeholders
+    toMatchArrCopy = toMatchArrCopy.map((toMatch) => {
+        let next_nr = 1;
+        let next_word = 1;
+        let toRet = toMatch;
+        while (toRet.includes(replNumber)) {
+            toRet = toRet.replace(replNumber, regExNrInsert.source.replace('?<NR__>', `?<NR_${next_nr}>`));
+            next_nr++;
+        }
+        while (toRet.includes(replWord)) {
+            toRet = toRet.replace(replWord, regExWordInsert.source.replace('?<W__>', `?<STATE_${next_word}>`));
+            next_word++;
+        }
+        return toRet;
+    });
+
+    return toMatchArrCopy.filter((v, i, a) => a.indexOf(v) === i).map((regExStr) => new RegExp(regExStr));
+}
+
+// from mdn web docs:
+function escapeRegExp(aString: string) {
+    return aString.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
+function longestCommonPrefix(startIndex: number, words: string[]): string {
+    if (!words[0] || words.length === 1) { return words[0] || ""; }
+    let i = startIndex;
+    // while all words have the same character at position i, increment i
+    while (words[0][i] && words.every(w => w[i] === words[0][i])) { i++; }
+
+    return words[0].slice(startIndex, i);
+}

--- a/src/test/suite/generateRegex.test.ts
+++ b/src/test/suite/generateRegex.test.ts
@@ -1,0 +1,104 @@
+/* --------------------
+ * Copyright(C) Matthias Behr. 2022
+ */
+
+var mocha = require('mocha');
+var describe = mocha.describe;
+var it = mocha.it;
+import { expect } from 'chai';
+import { generateRegex } from '../../generateRegex';
+
+describe('generate regex', () => {
+    it('should handle empty strings', () => {
+        const r = generateRegex([]);
+        expect(r).to.be.empty;
+    });
+
+    it('should handle single strings and add regex on numbers only', () => {
+        const r = generateRegex(['foo 42.1 bar']);
+        expect(r.length).to.equal(1);
+        expect(r[0]).to.eql(/^foo (?<NR_1>-?\d+(?:\.\d+)?) bar$/); // deep equality and not obj eq. -> eql
+        expect(r[0].test('foo 42.1 bar')).to.be.true;
+        expect(r[0].test('foo 1 bar')).to.be.true;
+        expect(r[0].test('foo -42 bar')).to.be.true;
+        expect(r[0].exec('foo -42.1 bar')).to.be.an('array').that.has.length(2); // only one value captured
+        expect(r[0].exec('foo -42.1 bar')).to.be.an('array').that.includes('-42.1');
+    });
+
+    it('should handle single strings and add regex on two numbers', () => {
+        const r = generateRegex(['foo 42.1 -4711bar']);
+        expect(r.length).to.equal(1);
+        expect(r[0].test('foo 42.1 bar')).to.be.false;
+        expect(r[0].test('foo 1 2bar')).to.be.true;
+        expect(r[0].test('foo 1 2 bar')).to.be.false;
+        expect(r[0].test('foo -42 -5bar')).to.be.true;
+        expect(r[0].exec('foo -42.1 -5bar')).to.be.an('array').that.has.length(3); // exactly two values captured
+        expect(r[0].exec('foo -42.1 -5bar')).to.be.an('array').that.include.members(['-42.1', '-5']);
+    });
+
+    it('should handle multiple strings and add regex capturing differences on word boundaries', () => {
+        const r = generateRegex(['foo bar end', 'foo baz end']); // we want prefixes to autodetect word boundaries , 'foo nonbar end']);
+        expect(r.length).to.equal(1);
+        expect(r[0].test('foo bar end')).to.be.true;
+        expect(r[0].test('foo baz end')).to.be.true;
+        expect(r[0].test('foo2 bar end')).to.be.false;
+        expect(r[0].test('foo blabla end')).to.be.true;
+        expect(r[0].exec('foo blabla end')).to.be.an('array').that.has.length(2);
+        expect(r[0].exec('foo blabla end')).to.be.an('array').that.include.members(['blabla']);
+    });
+
+    it('should handle multiple strings and add regex capturing differences on multiple word boundaries', () => {
+        const r = generateRegex(['foo bar middle bar end', 'foo baz middle baz end']); // we want prefixes to autodetect word boundaries , 'foo nonbar end']);
+        expect(r.length).to.equal(1);
+        expect(r[0].test('foo bar middle bar end')).to.be.true;
+        expect(r[0].test('foo baz middle baz end')).to.be.true;
+        expect(r[0].test('foo2 bar middle bar end')).to.be.false;
+        expect(r[0].test('foo blabla middle f end')).to.be.true;
+        expect(r[0].exec('foo blabla middle f end')).to.be.an('array').that.has.length(3);
+        expect(r[0].exec('foo blabla middle f end')).to.be.an('array').that.include.members(['blabla', 'f']);
+    });
+
+    it('should handle multiple strings and add regex capturing differences on multiple word boundaries ending', () => {
+        const r = generateRegex(['foo bar middle bar', 'foo baz middle baz']); // we want prefixes to autodetect word boundaries , 'foo nonbar end']);
+        expect(r.length).to.equal(1);
+        expect(r[0].test('foo bar middle bar')).to.be.true;
+        expect(r[0].test('foo baz middle baz')).to.be.true;
+        expect(r[0].test('foo2 bar middle bar')).to.be.false;
+        expect(r[0].test('foo blabla middle f')).to.be.true;
+        expect(r[0].exec('foo blabla middle f')).to.be.an('array').that.has.length(3);
+        expect(r[0].exec('foo blabla middle f')).to.be.an('array').that.include.members(['blabla', 'f']);
+    });
+
+    it('should handle multiple strings and add regex capturing differences on multiple word boundaries start', () => {
+        const r = generateRegex(['bar middle bar', 'baz middle baz']); // we want prefixes to autodetect word boundaries , 'foo nonbar end']);
+        expect(r.length).to.equal(1);
+        expect(r[0].test('bar middle bar')).to.be.true;
+        expect(r[0].test('baz middle baz')).to.be.true;
+        expect(r[0].test('bar middle2 bar')).to.be.false;
+        expect(r[0].test('blabla middle funky')).to.be.true;
+        expect(r[0].exec('blabla middle funky')).to.be.an('array').that.has.length(3);
+        expect(r[0].exec('blabla middle funky')).to.be.an('array').that.include.members(['blabla', 'funky']);
+    });
+
+    it('should handle multiple strings and add regex capturing differences on multiple word boundaries and numbers', () => {
+        const r = generateRegex(['-42.1bar middle bar', '1704baz middle baz']);
+        expect(r.length).to.equal(1);
+        expect(r[0].test('-41.2bar middle bar')).to.be.true;
+        expect(r[0].test('1704baz middle baz')).to.be.true;
+        expect(r[0].test('-41.2bar middle2 bar')).to.be.false;
+        expect(r[0].test('-41.2blabla middle funky')).to.be.true;
+        expect(r[0].exec('-41.2blabla middle funky')).to.be.an('array').that.has.length(4);
+        expect(r[0].exec('-41.2blabla middle funky')).to.be.an('array').that.include.members(['-41.2', 'blabla', 'funky']);
+    });
+
+    it('should handle multiple strings and add regex capturing multi word differences', () => {
+        const r = generateRegex(['start one two end', 'start three end']);
+        // we'd prefer this to be just 1? (capturing 'one two' and 'three' )?
+        // but currently its not like that but returns two regexs
+        expect(r.length).to.equal(2);
+        expect(r[0].test('start one two end')).to.be.true;
+        expect(r[1].test('start three end')).to.be.true;
+        expect(r[1].test('start2 three end')).to.be.false;
+    });
+
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -12,7 +12,7 @@
             "expect-webdriverio",
             "wdio-vscode-service"
         ],
-        "target": "es2019"
+        "target": "es2021"
     },
     "include": [
         "./**/*.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es2020",
+		"target": "es2021",
 		"outDir": "out",
 		"lib": [
-			"ES2020"
+			"es2021"
 		],
 		"sourceMap": true,
 		"rootDir": "src",
@@ -16,6 +16,7 @@
 	},
 	"exclude": [
 		"node_modules",
-		".vscode-test"
+		".vscode-test",
+		"test/**/*"
 	]
 }


### PR DESCRIPTION
Add "open quick report" and "open regex101 with quick report" to hover popup for logs where a basic regex can be generated automatically. Currently supported are number values (floats).