### PR TITLE
feat: add drag for tree view filter nodes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,7 +81,7 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 		},
 		dragAndDropController: {
-			dragMimeTypes: [], // ['text/uri-list'],
+			dragMimeTypes: ['application/vnd.dlt-logs+json'], // ['text/uri-list'],
 			dropMimeTypes: ['text/uri-list'],
 			async handleDrop(target: TreeViewNode | undefined, sources: vscode.DataTransfer, token: vscode.CancellationToken): Promise<void> {
 				let srcs: string[] = [];
@@ -97,7 +97,12 @@ export function activate(context: vscode.ExtensionContext) {
 				// for now we do pass all to the adltProvide
 				// but we might filter for .asc,... here already
 				return adltProvider.onDrop(target, sources, token);
-			}
+			},
+			handleDrag(source, dataTransfer, token): void | Thenable<void> {
+				console.log(`adlt.handleDrag #source=${source.length}...`);
+				// add json frags for filters to dataTransfer
+				return adltProvider.onDrag(source, dataTransfer, token);
+			},
 		}
 	});
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,11 @@
 			"es2021"
 		],
 		"sourceMap": true,
-		"rootDir": "src",
+		"rootDirs": [
+			"src",
+			"test"
+		],
+		// "rootDir": "src",
 		"strict": true   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */


### PR DESCRIPTION
Add application/vnd.dlt-logs+json with filterFrags property on drag of a node that reflects one or more filter:
- "Filter": all active filter
- Plugin: set filter that would be set
- Single filter.

Dragging should work within same extension host only so mainly intended to work with fishbone extension.