### PR TITLE
fix: quickPick doesn't allow entries

### DIFF
--- a/src/ask_user.ts
+++ b/src/ask_user.ts
@@ -92,9 +92,13 @@ export async function askSingleTime(refTime: Date, maxTime: Date | undefined): P
     };
 
     const timeUpdateHintOrError = (v: string, time: Date | undefined, hintOrErrorText?: string, error: boolean = false) => {
-        timeRestrictPIs[0].name = v;
-        timeRestrictPIs[0].description = `${hintOrErrorText !== undefined ? `${error ? 'Error: ' : ''}${hintOrErrorText} ` : ''}${time !== undefined ? time.toLocaleString() : ''}`;
-        timeRestrictMoreItemsEvent.fire(timeRestrictPIs);
+        const newDesc = `${hintOrErrorText !== undefined ? `${error ? 'Error: ' : ''}${hintOrErrorText} ` : ''}${time !== undefined ? time.toLocaleString() : ''}`;
+        // we must send the same value only once to avoid endless updates!
+        if (timeRestrictPIs[0].name !== v || timeRestrictPIs[0].description !== newDesc) {
+            timeRestrictPIs[0].name = v;
+            timeRestrictPIs[0].description = newDesc;
+            timeRestrictMoreItemsEvent.fire(timeRestrictPIs);
+        }
     };
 
     const timeOnValue = (v: string) => {

--- a/src/quickPick.ts
+++ b/src/quickPick.ts
@@ -60,6 +60,10 @@ export class QuickInputHelper {
                         ignoreNextAccept = false;
                         return;
                     }
+                    if (isValid !== undefined && !isValid(quickPick.value)) {
+                        console.log(`show onDidAccept() ignoring as value('${quickPick.value}') not valid!`);
+                        return;
+                    }
                     if (true || quickPick.canSelectMany) { // only via quickInputButton
                         quickPick.busy = true;
                         console.log(`show onDidAccept() got selectedItems.length=${quickPick.selectedItems.length} and value='${quickPick.value}'`);
@@ -79,7 +83,8 @@ export class QuickInputHelper {
                 disposables.push(quickPick.onDidChangeValue((value) => {
                     //console.log(`show onDidChangeValue() got value='${value}'`);
                     if (isValid !== undefined) {
-                        quickPick.enabled = isValid(value);
+                        // disables any input... quickPick.enabled = isValid(value);
+                        isValid(value); // triggers update of quickPicks
                     }
                 }));
 
@@ -104,6 +109,10 @@ export class QuickInputHelper {
                     } else
                         if (button instanceof QuickButton) {
                             console.log(`show onDidTrigger() QuickButton #selItems=${quickPick.selectedItems.length} value='${quickPick.value}'`);
+                            if (isValid !== undefined && !isValid(quickPick.value)) {
+                                console.log(`show onDidTrigger() ignoring as value('${quickPick.value}') not valid!`);
+                                return;
+                            }
                             quickPick.busy = true;
                             quickPick.enabled = false;
                             resolve(quickPick.selectedItems.length ? quickPick.selectedItems : quickPick.value);


### PR DESCRIPTION
Quickpick was completely disabled if the isValid value was not true. In prev. vscode versions this did just disable the "accept" but not any further entries.
At least with vsc 1.73 this seems changed.