### PR TITLE
fix(report): hotfix to reenable zoom on resize

### DIFF
--- a/media/regularGraphs.js
+++ b/media/regularGraphs.js
@@ -379,6 +379,7 @@ const graphConfigTemplate = {
     },
     options: {
         responsive: true,
+        maintainAspectRatio: true,
         layout: {
             padding: {
                 left: 0,

--- a/media/timeSeriesReport.html
+++ b/media/timeSeriesReport.html
@@ -132,7 +132,12 @@
     <div id="message">
         <textarea id="report_filenames" rows="1" cols="120" readonly>dlt-logs report ok: unknown</textarea>
         <pre id="report_warnings" hidden></pre>
-        <div id="stacked-reports">
+        <div id="stacked-reports" style="position: relative; height:auto; width:auto">
+            <!-- hotfix to avoid https://github.com/chartjs/Chart.js/issues/11139 Needs to be removed once fixed
+                this adds a 20px gap on top of first chart and thus screws the e2etests but it's better than 
+                the bug which prevents zooming single charts on resize
+            -->
+            <canvas id="not_used" style="width:0; height:0;"></canvas>
         </div>
     </div>
     <br>


### PR DESCRIPTION
If a single chart is drawn on resize/increase window size the chart is not redrawn/resized.
This seems to be due to
https://github.com/chartjs/Chart.js/issues/11139

Added a workaround by adding 2nd canvas.
This adds a small padding and thus invalidates the end-end tests but strangely helps to avoid the issue.