### PR TITLE
fix: quick report/add filter with multiple files

### DIFF
--- a/src/adltDocumentProvider.ts
+++ b/src/adltDocumentProvider.ts
@@ -1582,7 +1582,7 @@ export class AdltDocument implements vscode.Disposable {
             `| ctid | ${msg.ctid}${ctidDesc} |\n`);
         mdString.appendMarkdown(`\n\n-- -\n\n`);
 
-        const args = [{ uri: this.uri.toString() }, { mstp: msg.mstp, ecu: msg.ecu, apid: msg.apid, ctid: msg.ctid, payload: msg.payloadString }];
+        const args = [{ uri: this.uri.toString(), base64Uri: Buffer.from(this.uri.toString()).toString('base64') }, { mstp: msg.mstp, ecu: msg.ecu, apid: msg.apid, ctid: msg.ctid, payload: msg.payloadString }];
         const addCommandUri = vscode.Uri.parse(`command:dlt-logs.addFilter?${encodeURIComponent(JSON.stringify(args))}`);
 
         mdString.appendMarkdown(`[$(filter) add filter... ](${addCommandUri})`);
@@ -1608,8 +1608,11 @@ export class AdltDocument implements vscode.Disposable {
             const regexs = generateRegex(payloads);
             console.log(`AdltDocument.provideHover regexs='${regexs.map((v) => '/' + v.source + '/').join(',')}'`);
             if (regexs.length === 1 && regexs[0].source.includes('(?<')) {
-                const args = [{ uri: this.uri.toString() }, { type: 3, mstp: msg.mstp, apid: msg.apid, ctid: msg.ctid, payloadRegex: regexs[0].source }];
+                // added encoding of the uri using base64 but the same problem can happen with payloadRegex as well...
+                // filed https://github.com/microsoft/vscode/issues/179962 to have it fixed/analysed within vscode.
+                const args = [{ uri: this.uri.toString(), base64Uri: Buffer.from(this.uri.toString()).toString('base64') }, { type: 3, mstp: msg.mstp, apid: msg.apid, ctid: msg.ctid, payloadRegex: regexs[0].source }];
                 const addCommandUri = vscode.Uri.parse(`command:dlt-logs.openReport?${encodeURIComponent(JSON.stringify(args))}`);
+                // console.warn(`quick report openReport with command uri:'${addCommandUri}' for doc uri:'${this.uri.toString()}'`);
                 mdString.appendMarkdown(`[$(graph) open quick report... ](${addCommandUri})`);
                 mdString.appendMarkdown(`[$(globe) open regex101.com with quick report...](https://regex101.com/?flavor=javascript&regex=${encodeURIComponent(args[1].payloadRegex || '')}&testString=${encodeURIComponent(payloads.slice(0, 20).join('\n'))})`);
                 /*mdString.appendMarkdown(`\n\n-- -\n\n`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -336,8 +336,8 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.commands.registerCommand("dlt-logs.addFilter", async (...args) => {
 		args.forEach(a => { console.log(` dlt-logs.addFilter arg='${JSON.stringify(a)}'`); });
 		if (args.length < 2) { return; }
-		// first arg should contain uri
-		const uri = typeof args[0].uri === 'string' ? vscode.Uri.parse(args[0].uri) : args[0].uri;
+		// first arg should contain uri or preferrably base64Uri
+		const uri = 'base64Uri' in args[0] ? vscode.Uri.parse(Buffer.from(args[0].base64Uri, 'base64').toString('utf8')) : (typeof args[0].uri === 'string' ? vscode.Uri.parse(args[0].uri) : args[0].uri);
 		if (uri) {
 			let { doc, provider } = getDocAndProviderFor(uri.toString());
 			if (doc) {
@@ -417,10 +417,10 @@ export function activate(context: vscode.ExtensionContext) {
 			filter = filterNode.filter;
 			uri = filterNode.parent?.uri;
 		} else {
-			console.log(`dlt-logs.openReport using two args')`);
+			console.log(`dlt-logs.openReport using two args: '${JSON.stringify(args[0])}' and '${JSON.stringify(args[1])}')`);
 			filter = new DltFilter(args[1]);
 			label = filter.name;
-			uri = vscode.Uri.parse(args[0].uri);
+			uri = vscode.Uri.parse('base64Uri' in args[0] ? Buffer.from(args[0].base64Uri, 'base64').toString('utf8') : args[0].uri);
 		}
 		if (uri) {
 			const doc = dltProvider._documents.get(uri.toString());


### PR DESCRIPTION
If multiple log files have been opened as one document the quick filter and add filter from hover menu didn't work. Created https://github.com/microsoft/vscode/issues/179962 for vscode and added a workaround.