### PR TITLE
fix(can): multiple can files did wrongly overlap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
 				"vscode": "^1.67.0"
 			},
 			"optionalDependencies": {
-				"node-adlt": "0.36.0"
+				"node-adlt": "0.36.2"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -9209,9 +9209,9 @@
 			"optional": true
 		},
 		"node_modules/node-adlt": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.36.0.tgz",
-			"integrity": "sha512-iK5TtlgjKNb89n4fI5fiK80BZiVtC8y5sFnBsxyheXxyRPJyFm6KlOkSH0Bgnll6jy0MuAOkME2Lrg5le921Rg==",
+			"version": "0.36.2",
+			"resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.36.2.tgz",
+			"integrity": "sha512-DtwVDXWP6sWNuIl2WAtFeTATLmBdvgh9FPc07iDF6lQJw8P5waurudB27L+Ycld2qG4crtd70apFRluxbtTemg==",
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
@@ -23367,9 +23367,9 @@
 			"optional": true
 		},
 		"node-adlt": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.36.0.tgz",
-			"integrity": "sha512-iK5TtlgjKNb89n4fI5fiK80BZiVtC8y5sFnBsxyheXxyRPJyFm6KlOkSH0Bgnll6jy0MuAOkME2Lrg5le921Rg==",
+			"version": "0.36.2",
+			"resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.36.2.tgz",
+			"integrity": "sha512-DtwVDXWP6sWNuIl2WAtFeTATLmBdvgh9FPc07iDF6lQJw8P5waurudB27L+Ycld2qG4crtd70apFRluxbtTemg==",
 			"optional": true,
 			"requires": {
 				"https-proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -907,7 +907,7 @@
 		"ws": "^8.13.0"
 	},
 	"optionalDependencies": {
-		"node-adlt": "0.36.0"
+		"node-adlt": "0.36.2"
 	},
 	"commitlint": {
 		"extends": [


### PR DESCRIPTION
Opening multiple CAN files lead to an overlap due to the "date" in .asc files having sec granularity only.
Fixed handling of those cases.