### PR TITLE
fix(report): show warning if truncation happens

### DIFF
--- a/docs/dlt-logs/docs/reports.md
+++ b/docs/dlt-logs/docs/reports.md
@@ -110,6 +110,12 @@ If you click on a data point in the report the DLT log window tries to scroll th
 
 You can define event filters (type: 3), add normal filters like ecu, apid, ctid and use a payloadRegex that captures either one value or even multiple values with named capture groups (?\<series\_name\>.*). 
 
+:::note
+The amount of log messages processed for a report is limited to avoid long processing times. The default limit is 1 mio logs but you can change
+it with the config setting `dlt-logs.maxReportLogs`.
+A warning will be shown in the report if you hit the limit.
+:::
+
 ### Capture group names and types
 
 By default all captures needs will be parsed as float numbers. You can change that behaviour by prefixing the capure name with STATE\_ or INT\_ (see below).

--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
 						"default": 400000,
 						"description": "Maximum number of DLT logs that are shown in one page. If more messages do exist a paging mechanism will reload at 4/5th the next chunk. You can only search within that page. Please consider using filter to stay within that limit. Defaults to 400'000."
 					},
+					"dlt-logs.maxReportLogs": {
+						"type": "integer",
+						"default": 1000000,
+						"description": "Maximum number of DLT logs rendered for a graphical report. You'll get a warning within the report if the limit is hit."
+					},
 					"dlt-logs.columns": {
 						"type": "array",
 						"items": {


### PR DESCRIPTION
Add config setting dlt-logs.maxReportLogs and show a warning within the report if the limit is met and the report does show only a truncated amount of logs.