### PR TITLE
fix: dlt strings are non zero terminated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
 				"vscode": "^1.67.0"
 			},
 			"optionalDependencies": {
-				"node-adlt": "0.40.0"
+				"node-adlt": "0.40.1"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -9209,9 +9209,9 @@
 			"optional": true
 		},
 		"node_modules/node-adlt": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.40.0.tgz",
-			"integrity": "sha512-F9zoLBasbwWZpGDDzu+3rBihNq102Td+fkaEb/E36DjXpdngWk4f741nKRSRKbjIk7eSQ3Jy5XKxjYFD+XtC/A==",
+			"version": "0.40.1",
+			"resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.40.1.tgz",
+			"integrity": "sha512-dhfaiolp0oD+pDlIcGMxUhv1u20YDfkYCQpP8HlCpbiu72XkuQG0YGtzWMWjicsJMVlzvv5riVuwt5mopWivNg==",
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
@@ -23367,9 +23367,9 @@
 			"optional": true
 		},
 		"node-adlt": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.40.0.tgz",
-			"integrity": "sha512-F9zoLBasbwWZpGDDzu+3rBihNq102Td+fkaEb/E36DjXpdngWk4f741nKRSRKbjIk7eSQ3Jy5XKxjYFD+XtC/A==",
+			"version": "0.40.1",
+			"resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.40.1.tgz",
+			"integrity": "sha512-dhfaiolp0oD+pDlIcGMxUhv1u20YDfkYCQpP8HlCpbiu72XkuQG0YGtzWMWjicsJMVlzvv5riVuwt5mopWivNg==",
 			"optional": true,
 			"requires": {
 				"https-proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -941,7 +941,7 @@
 		"ws": "^8.13.0"
 	},
 	"optionalDependencies": {
-		"node-adlt": "0.40.0"
+		"node-adlt": "0.40.1"
 	},
 	"commitlint": {
 		"extends": [


### PR DESCRIPTION
by spec but some client libs do so.
Add support for non-zero term strings and autodection for zero-terminated ones.