### PR TITLE
feat(logcat): add experimental support for logcat files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
 				"vscode": "^1.67.0"
 			},
 			"optionalDependencies": {
-				"node-adlt": "0.40.1"
+				"node-adlt": "0.41.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -9209,9 +9209,9 @@
 			"optional": true
 		},
 		"node_modules/node-adlt": {
-			"version": "0.40.1",
-			"resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.40.1.tgz",
-			"integrity": "sha512-dhfaiolp0oD+pDlIcGMxUhv1u20YDfkYCQpP8HlCpbiu72XkuQG0YGtzWMWjicsJMVlzvv5riVuwt5mopWivNg==",
+			"version": "0.41.0",
+			"resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.41.0.tgz",
+			"integrity": "sha512-1nf9H9kfUx1iON4sttFBW7xy6/WETXPyaLTCOEuV4DLHZL/xGcKXqfvmzziM9GcQ6/uhzVLgSYJ83aSs0zw0bw==",
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
@@ -23367,9 +23367,9 @@
 			"optional": true
 		},
 		"node-adlt": {
-			"version": "0.40.1",
-			"resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.40.1.tgz",
-			"integrity": "sha512-dhfaiolp0oD+pDlIcGMxUhv1u20YDfkYCQpP8HlCpbiu72XkuQG0YGtzWMWjicsJMVlzvv5riVuwt5mopWivNg==",
+			"version": "0.41.0",
+			"resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.41.0.tgz",
+			"integrity": "sha512-1nf9H9kfUx1iON4sttFBW7xy6/WETXPyaLTCOEuV4DLHZL/xGcKXqfvmzziM9GcQ6/uhzVLgSYJ83aSs0zw0bw==",
 			"optional": true,
 			"requires": {
 				"https-proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -941,7 +941,7 @@
 		"ws": "^8.13.0"
 	},
 	"optionalDependencies": {
-		"node-adlt": "0.40.1"
+		"node-adlt": "0.41.0"
 	},
 	"commitlint": {
 		"extends": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,11 +202,12 @@ export function activate(context: vscode.ExtensionContext) {
 		if (Array.isArray(file_exts)) {
 			if (!file_exts.includes("dlt")) { file_exts.push("dlt"); }
 			if (!file_exts.includes("asc")) { file_exts.push("asc"); }
+			if (!file_exts.includes("txt")) { file_exts.push("txt"); }
 		} else {
-			file_exts = ["dlt", "asc"];
+			file_exts = ["dlt", "asc", "txt"];
 		}
 		console.log(`open dlt via adlt file_exts=${JSON.stringify(file_exts)}`);
-		return vscode.window.showOpenDialog({ canSelectFiles: true, canSelectFolders: false, canSelectMany: true, filters: { 'DLT Logs': file_exts }, openLabel: 'Select DLT or CAN file(s) to open...' }).then(
+		return vscode.window.showOpenDialog({ canSelectFiles: true, canSelectFolders: false, canSelectMany: true, filters: { 'DLT Logs': file_exts }, openLabel: 'Select DLT, CAN or Logcat file(s) to open...' }).then(
 			async (uris: vscode.Uri[] | undefined) => {
 				if (uris) {
 					console.log(`open dlt via adlt got URIs=${uris}`);


### PR DESCRIPTION
Logcat files in default format e.g. "logcat -b all" stored with .txt extension can be opened as dlt files.
ECU will be dynamically assigned (LCxy)
Apid is an abbrevation of the tag incl. description. Ctid is fixed "LogC".

Opening multiple files might have some wrong sort order!