### PR TITLE
feat: add dlt-logs-utils support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "chartjs-adapter-moment": "^1.0.1",
         "chartjs-plugin-annotation": "^2.2.1",
         "chartjs-plugin-zoom": "^2.0.1",
+        "dlt-logs-utils": "0.0.2",
         "fast-xml-parser": "^3.19.0",
         "hammerjs": "^2.0.8",
         "hw-chartjs-plugin-colorschemes": "0.5.4",
@@ -5458,6 +5459,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dlt-logs-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/dlt-logs-utils/-/dlt-logs-utils-0.0.2.tgz",
+      "integrity": "sha512-ApjoO5ng57axu6KEa7tHU8nv1dgpa4yYMmFRCshCW85+44Wzv+1iEIuoV0LiID+9Hay9wt0czwdDBOa1qn74ug=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -20473,6 +20479,11 @@
       "requires": {
         "path-type": "^4.0.0"
       }
+    },
+    "dlt-logs-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/dlt-logs-utils/-/dlt-logs-utils-0.0.2.tgz",
+      "integrity": "sha512-ApjoO5ng57axu6KEa7tHU8nv1dgpa4yYMmFRCshCW85+44Wzv+1iEIuoV0LiID+9Hay9wt0czwdDBOa1qn74ug=="
     },
     "doctrine": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -929,6 +929,7 @@
     "chartjs-adapter-moment": "^1.0.1",
     "chartjs-plugin-annotation": "^2.2.1",
     "chartjs-plugin-zoom": "^2.0.1",
+    "dlt-logs-utils": "0.0.2",
     "fast-xml-parser": "^3.19.0",
     "hammerjs": "^2.0.8",
     "hw-chartjs-plugin-colorschemes": "0.5.4",

--- a/src/dltReport.ts
+++ b/src/dltReport.ts
@@ -6,14 +6,18 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as JSON5 from 'json5';
+import * as uv0 from 'dlt-logs-utils';
 import { DltLifecycleInfoMinIF } from './dltLifecycle';
 import { DltFilter } from './dltFilter';
 import { FilterableDltMsg } from './dltParser';
 import { TreeViewNode } from './dltTreeViewNodes';
 
-// make JSON5 available for conversionFunction by adding to globalThis
-if (!((globalThis as any).JSON5)) {
-    (globalThis as any).JSON5 = JSON5;
+// make JSON5 and dlt-logs-utils available for conversionFunction by adding to globalThis
+if (!(globalThis as any).JSON5) {
+  (globalThis as any).JSON5 = JSON5;
+}
+if (!(globalThis as any).uv0) {
+  (globalThis as any).uv0 = uv0;
 }
 
 enum DataPointType {


### PR DESCRIPTION
Import dlt-logs-utils as uv0 (utils version 0) for conversion functions. Allows e.g. return new TL('group','lane',matches[1], {color:'red'})