### PR TITLE
fix: improve reveal accurracy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "vscode": "^1.67.0"
       },
       "optionalDependencies": {
-        "node-adlt": "0.47.4"
+        "node-adlt": "0.48.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10394,9 +10394,9 @@
       "optional": true
     },
     "node_modules/node-adlt": {
-      "version": "0.47.4",
-      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.47.4.tgz",
-      "integrity": "sha512-SRBUz7x4bmvYU1cpvJGZo19cJBENdob1KdFlViYRbTndAKuDgKzopyYyMdtoLZWCozUUJ+rsA1u7hclZDg/Mbw==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.48.0.tgz",
+      "integrity": "sha512-NeqJqjJiqg/GzU2yWsRTkqCXuNuIUy57Rv6uiDGLDJtF3X79MNRnhHBaVJVNZmDy18z9AVhzxTEEP07CHkpzww==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -26074,9 +26074,9 @@
       "optional": true
     },
     "node-adlt": {
-      "version": "0.47.4",
-      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.47.4.tgz",
-      "integrity": "sha512-SRBUz7x4bmvYU1cpvJGZo19cJBENdob1KdFlViYRbTndAKuDgKzopyYyMdtoLZWCozUUJ+rsA1u7hclZDg/Mbw==",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.48.0.tgz",
+      "integrity": "sha512-NeqJqjJiqg/GzU2yWsRTkqCXuNuIUy57Rv6uiDGLDJtF3X79MNRnhHBaVJVNZmDy18z9AVhzxTEEP07CHkpzww==",
       "optional": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -970,7 +970,7 @@
     "ws": "^8.13.0"
   },
   "optionalDependencies": {
-    "node-adlt": "0.47.4"
+    "node-adlt": "0.48.0"
   },
   "commitlint": {
     "extends": [

--- a/src/panels/SearchPanel.ts
+++ b/src/panels/SearchPanel.ts
@@ -459,12 +459,10 @@ export class SearchPanelProvider implements WebviewViewProvider {
                 } else {
                   this._activeDoc.setMsgTimeHighlights('SearchPanel', [{ msgIndex: req.index, calculatedTimeInMs: req.timeInMs }])
                 }
+                this._activeDoc.revealMsgIndex(0 + req.index) // or only if we did set highlight? for now do it always
               } else {
                 this._activeDoc.setMsgTimeHighlights('SearchPanel', [])
-              }
-              if (req.timeInMs) {
-                // todo support revealByIndex(req.index) and only fallback to time... (or add to revealDate...)
-                this._activeDoc.revealDate(new Date(req.timeInMs))
+                // we dont reveal here, just clear highlights
               }
             }
             break


### PR DESCRIPTION
The reveal e.g. of search results was using the time in ms granularity only. This can be very coarse in cases of plenty of logs with similar times. Using the new binary_search by index from adlt 0.48.0 to get closer to the real msg.