### PR TITLE
fix: toggle sort order triggers no update of the document

### DIFF
--- a/src/adltPlugin.ts
+++ b/src/adltPlugin.ts
@@ -334,7 +334,7 @@ export class AdltPlugin implements TreeViewNode {
 
   // state updates from adlt for that plugin
   processStateUpdate(state: any): void {
-    console.log(`AdltPlugin(${this.options.name}).processStateUpdate(${JSON.stringify(state)})...`)
+    //console.log(`AdltPlugin(${this.options.name}).processStateUpdate(${JSON.stringify(state)})...`)
     if ('treeItems' in state && Array.isArray(state.treeItems)) {
       this.children.length = 0 // for now no updates but delete, add
       // add our child nodes:


### PR DESCRIPTION
Root cause where cases where due to the different order the text length did not change. Those cases did not lead to updates. Fixed by explicitly updating "mtime" on any text change.