### PR TITLE
fix(search): use full .1ms precision

### DIFF
--- a/src/panels/SearchPanel.ts
+++ b/src/panels/SearchPanel.ts
@@ -399,7 +399,7 @@ export class SearchPanelProvider implements WebviewViewProvider {
                           return {
                             index: m.index,
                             receptionTimeInMs: m.receptionTimeInMs,
-                            calculatedTimeInMs: doc.provideTimeByMsg(m)?.valueOf(),
+                            calculatedTimeInMs: doc.provideTimeByMsgInMs(m),
                             timeStamp: m.timeStamp,
                             ecu: m.ecu,
                             mcnt: m.mcnt,


### PR DESCRIPTION
Avoid conversion via Date constructor that seems to loose sub ms precision.