### PR TITLE
feat: use adlt 0.53.0 incl fibex warnings and perf optimizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "vscode": "^1.83.0"
       },
       "optionalDependencies": {
-        "node-adlt": "0.52.1"
+        "node-adlt": "0.53.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10394,9 +10394,9 @@
       "optional": true
     },
     "node_modules/node-adlt": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.52.1.tgz",
-      "integrity": "sha512-+AkxS+fSPIFRnEX7BFI4Z4FkN//qCxObeq88fChlqxyl27xXYWbwiDvYrL6x0elE41qW9LFe3Z3mEdAywuORIQ==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.53.0.tgz",
+      "integrity": "sha512-9Tm1LNw/+uMYHr724skgSW7e/8+zCBtDTcmE/g/AzyOxdgNB0V7O4+m27dly7uvtL1oAxd2ZIQx4KZF3LHm7+w==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -26078,9 +26078,9 @@
       "optional": true
     },
     "node-adlt": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.52.1.tgz",
-      "integrity": "sha512-+AkxS+fSPIFRnEX7BFI4Z4FkN//qCxObeq88fChlqxyl27xXYWbwiDvYrL6x0elE41qW9LFe3Z3mEdAywuORIQ==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.53.0.tgz",
+      "integrity": "sha512-9Tm1LNw/+uMYHr724skgSW7e/8+zCBtDTcmE/g/AzyOxdgNB0V7O4+m27dly7uvtL1oAxd2ZIQx4KZF3LHm7+w==",
       "optional": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -969,7 +969,7 @@
     "ws": "^8.13.0"
   },
   "optionalDependencies": {
-    "node-adlt": "0.52.1"
+    "node-adlt": "0.53.0"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
Any fibex warnings are now added to the Warnings section within the plugin tree. Prev. they had been output to the console only.

Contains performance optimizations from adlt as well. Mainly to reduce memory allocator pressure.