### PR TITLE
fix(can): support asc files with multiple whitespaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "vscode": "^1.83.0"
       },
       "optionalDependencies": {
-        "node-adlt": "0.56.1"
+        "node-adlt": "0.56.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10469,9 +10469,9 @@
       "optional": true
     },
     "node_modules/node-adlt": {
-      "version": "0.56.1",
-      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.56.1.tgz",
-      "integrity": "sha512-2UtRllgTaGeHKj1oYqFEMIEYJItH+GQlciLwy0yomeo8GxvBfoKkHG2j1MrHsRki3pnJN/6uws3lZHj9J/Mf5g==",
+      "version": "0.56.2",
+      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.56.2.tgz",
+      "integrity": "sha512-2+vTcg/IpCQAJ5oL8mHSuEESscTaUNkaQI02aHDVKT8SjmVGeDfpSSSN84RatDB63yI4beFkZHGbkfTbka6hgw==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -26221,9 +26221,9 @@
       "optional": true
     },
     "node-adlt": {
-      "version": "0.56.1",
-      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.56.1.tgz",
-      "integrity": "sha512-2UtRllgTaGeHKj1oYqFEMIEYJItH+GQlciLwy0yomeo8GxvBfoKkHG2j1MrHsRki3pnJN/6uws3lZHj9J/Mf5g==",
+      "version": "0.56.2",
+      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.56.2.tgz",
+      "integrity": "sha512-2+vTcg/IpCQAJ5oL8mHSuEESscTaUNkaQI02aHDVKT8SjmVGeDfpSSSN84RatDB63yI4beFkZHGbkfTbka6hgw==",
       "optional": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -975,7 +975,7 @@
     "ws": "^8.13.0"
   },
   "optionalDependencies": {
-    "node-adlt": "0.56.1"
+    "node-adlt": "0.56.2"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
and fix date support with milliseconds.
Use adlt 0.56.2 which contains the two fixes.