### PR TITLE
feat(unzip): support direct opening of zip archives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "prettier": "^3.1.1",
         "semantic-release": "^22.0.5",
         "ts-node": "^10.9.1",
-        "typescript": "^5.2.2",
+        "typescript": "^5.4.5",
         "wdio-vscode-service": "^5.2.2",
         "webdriverio": "^8.13.13"
       },
@@ -69,7 +69,7 @@
         "vscode": "^1.87.0"
       },
       "optionalDependencies": {
-        "node-adlt": "0.57.1"
+        "node-adlt": "0.58.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10469,9 +10469,9 @@
       "optional": true
     },
     "node_modules/node-adlt": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.57.1.tgz",
-      "integrity": "sha512-4qwGAtOJoVGU9dHiVPLFzeBPzNFBMg4pU33bHt8PZB7jvAAZ2Y8JvnJw9pF44YgBgMBGqlbQKu0eaNiK1rjfPQ==",
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.58.0.tgz",
+      "integrity": "sha512-Axc8/d9p4qe0n1Xd3tP4pnuph1sXQ8tOCgCGHeqM4FYrP/M2wXfrDwF2TXowP9KeRceoeO2QTcV8txUnY32Ldw==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -17554,9 +17554,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -26221,9 +26221,9 @@
       "optional": true
     },
     "node-adlt": {
-      "version": "0.57.1",
-      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.57.1.tgz",
-      "integrity": "sha512-4qwGAtOJoVGU9dHiVPLFzeBPzNFBMg4pU33bHt8PZB7jvAAZ2Y8JvnJw9pF44YgBgMBGqlbQKu0eaNiK1rjfPQ==",
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.58.0.tgz",
+      "integrity": "sha512-Axc8/d9p4qe0n1Xd3tP4pnuph1sXQ8tOCgCGHeqM4FYrP/M2wXfrDwF2TXowP9KeRceoeO2QTcV8txUnY32Ldw==",
       "optional": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",
@@ -31215,9 +31215,9 @@
       }
     },
     "typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true
     },
     "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -1034,7 +1034,7 @@
     "prettier": "^3.1.1",
     "semantic-release": "^22.0.5",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.2",
+    "typescript": "^5.4.5",
     "wdio-vscode-service": "^5.2.2",
     "webdriverio": "^8.13.13"
   },
@@ -1061,7 +1061,7 @@
     "ws": "^8.13.0"
   },
   "optionalDependencies": {
-    "node-adlt": "0.57.1"
+    "node-adlt": "0.58.0"
   },
   "commitlint": {
     "extends": [

--- a/src/adltRemoteFsProvider.ts
+++ b/src/adltRemoteFsProvider.ts
@@ -162,7 +162,7 @@ export class AdltRemoteFSProvider implements vscode.FileSystemProvider {
 
   stat(uri: vscode.Uri): vscode.FileStat | Thenable<vscode.FileStat> {
     const log = this.log
-    log.trace(`AdltRemoteFSProvider.stat(uri=${uri.toString().slice(0, 100)}...`)
+    log.trace(`AdltRemoteFSProvider.stat(uri=${uri.toString().slice(0, 100)})...`)
     // this is a weird hack as the openFileDialog has issues if the path is only /
     // so we add /fs/ to the path and remove it towards adlt then
     if (!uri.path.startsWith('/fs')) {
@@ -172,7 +172,7 @@ export class AdltRemoteFSProvider implements vscode.FileSystemProvider {
     const path = uri.path.startsWith('/fs') ? uri.path.slice(3) : uri.path
     return this.sendAndRecv(`fs ${JSON.stringify({ cmd: 'stat', path })}`).then(
       (resp) => {
-        log.trace(`AdltRemoteFSProvider.stat(uri=${uri.toString().slice(0, 100)}... got resp='${resp.slice(0, 100)}...'`)
+        log.info(`AdltRemoteFSProvider.stat(uri=${uri.toString().slice(0, 100)})... got resp='${resp.slice(0, 100)}...'`)
         if (resp.startsWith('ok: fs:')) {
           const respObj = JSON.parse(resp.slice(7))
           // log.info(`AdltRemoteFSProvider.stat(${uri.path}) respObj=${JSON.stringify(respObj)}`)
@@ -185,7 +185,7 @@ export class AdltRemoteFSProvider implements vscode.FileSystemProvider {
               mtime: stat.mtime || 0,
               type: AdltRemoteFSProvider.convertAdltFileTypeToVscodeFileType(stat.type),
             }
-            log.trace(`AdltRemoteFSProvider.stat(${uri.path})=${JSON.stringify(toRet)}`)
+            log.info(`AdltRemoteFSProvider.stat(${uri.path})=${JSON.stringify(toRet)}`)
             return toRet
           }
         } else {
@@ -230,11 +230,11 @@ export class AdltRemoteFSProvider implements vscode.FileSystemProvider {
               return [entry.name, AdltRemoteFSProvider.convertAdltFileTypeToVscodeFileType(entry.type)]
             })
             entries = entries.filter((e) => !e[0].startsWith('.')) // we remove all hidden files
-            // log.info(`AdltRemoteFSProvider.readDirectory entries=${JSON.stringify(entries)}`)
+            log.info(`AdltRemoteFSProvider.readDirectory entries=${JSON.stringify(entries)}`)
             return entries
           }
         }
-        log.warn(`AdltRemoteFSProvider.readDirectory(uri=${uri.toString().slice(0, 100)}... got nok resp='${resp.slice(0, 100)}...'`)
+        log.warn(`AdltRemoteFSProvider.readDirectory(uri=${uri.toString().slice(0, 200)}... got nok resp='${resp.slice(0, 100)}...'`)
         return []
       },
       (reason) => {

--- a/src/remote_types.ts
+++ b/src/remote_types.ts
@@ -8,6 +8,7 @@ export type BinType =
   | { tag: 'EacInfo'; value: Array<BinEcuStats> }
   | { tag: 'PluginState'; value: Array<string> }
   | { tag: 'StreamInfo'; value: BinStreamInfo }
+  | { tag: 'Progress'; value: BinProgress }; 
 
 export module BinType {
   export const FileInfo = (value: BinFileInfo): BinType => ({ tag: 'FileInfo', value })
@@ -16,6 +17,7 @@ export module BinType {
   export const EacInfo = (value: Array<BinEcuStats>): BinType => ({ tag: 'EacInfo', value })
   export const PluginState = (value: Array<string>): BinType => ({ tag: 'PluginState', value })
   export const StreamInfo = (value: BinStreamInfo): BinType => ({ tag: 'StreamInfo', value })
+  export const Progress = (value: BinProgress): BinType => ({ tag: 'Progress', value })
 }
 
 export function writeBinType(value: BinType, sinkOrBuf?: SinkOrBuf): Sink {
@@ -51,6 +53,11 @@ export function writeBinType(value: BinType, sinkOrBuf?: SinkOrBuf): Sink {
       const val6 = value as { value: BinStreamInfo }
       writeBinStreamInfo(val6.value, sink)
       break
+    case 'Progress':
+      writeU32(6, sink)
+      const val7 = value as { value: BinProgress }
+      writeBinProgress(val7.value, sink)
+      break
     default:
       throw new Error(`'${(value as any).tag}' is invalid tag for enum 'BinType'`)
   }
@@ -74,6 +81,8 @@ export function readBinType(sinkOrBuf: SinkOrBuf): BinType {
       return BinType.PluginState(readSeq(readString)(sink))
     case 5:
       return BinType.StreamInfo(readBinStreamInfo(sink))
+    case 6:
+      return BinType.Progress(readBinProgress(sink))
     default:
       throw new Error(`'${value}' is invalid value for enum 'BinType'`)
   }
@@ -273,6 +282,29 @@ export function readBinStreamInfo(sinkOrBuf: SinkOrBuf): BinStreamInfo {
     nr_stream_msgs: readU32(sink),
     nr_file_msgs_processed: readU32(sink),
     nr_file_msgs_total: readU32(sink),
+  }
+}
+
+export interface BinProgress {
+  cur_progress: number
+  max_progress: number
+  action: string
+}
+
+export function writeBinProgress(value: BinProgress, sinkOrBuf?: SinkOrBuf): Sink {
+  const sink = Sink.create(sinkOrBuf)
+  writeU32(value.cur_progress, sink)
+  writeU32(value.max_progress, sink)
+  writeString(value.action, sink)
+  return sink
+}
+
+export function readBinProgress(sinkOrBuf: SinkOrBuf): BinProgress {
+  const sink = Sink.create(sinkOrBuf)
+  return {
+    cur_progress: readU32(sink),
+    max_progress: readU32(sink),
+    action: readString(sink),
   }
 }
 


### PR DESCRIPTION
For windows currently .zip and multi-volume .zip.001 are supported. For mac .7z, .tgz, ... are supported as well.
Archive support is provided via adlt 0.58.0.