### PR TITLE
fix(unzip): normalize paths within multiple files

### DIFF
--- a/src/adltDocumentProvider.ts
+++ b/src/adltDocumentProvider.ts
@@ -47,6 +47,7 @@ import { generateRegex } from './generateRegex'
 import * as JSON5 from 'json5'
 import { AdltRemoteFSProvider } from './adltRemoteFsProvider'
 import { AdltCommentThread, AdltComment, restoreComments, persistComments, purgeOldComments } from './adltComments'
+import { normalizeArchivePaths } from './util'
 
 //import { adltPath } from 'node-adlt';
 // with optionalDependency we use require to catch errors
@@ -249,9 +250,9 @@ export function decodeAdltUri(uri: vscode.Uri): string[] {
         // console.warn(`adlt got encoded jsonObj=${JSON.stringify(jsonObj)}`);
         // we use the multiple files only if the first entry is same as path
         // this is to prevent vscode automatic changes of uris e.g. on breadcrumb selecction
-        let allFileNames = jsonObj.lf.filter((f: any) => typeof f === 'string').map((f: string) => path.resolve(basePath, f))
+        let allFileNames: string[] = jsonObj.lf.filter((f: any) => typeof f === 'string').map((f: string) => path.resolve(basePath, f))
         if (allFileNames.length > 1 && allFileNames[0] === fileNames[0]) {
-          fileNames = allFileNames
+          fileNames = allFileNames.map(normalizeArchivePaths)
         } else {
           // this is not a bug:
           //console.log(`adlt got encoded allFiles not matching first file`, allFileNames, fileNames[0])

--- a/src/test/suite/util.test.ts
+++ b/src/test/suite/util.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 
 import { generateRegex } from '../../generateRegex'
-import { partitionPoint } from '../../util'
+import { partitionPoint, normalizeArchivePaths } from '../../util'
 
 suite('Util Test Suite', () => {
   test('partitionPoint', () => {
@@ -27,5 +27,15 @@ suite('Util Test Suite', () => {
     const arr: any[] = []
     const index = partitionPoint(arr, (x) => x < 8)
     assert.strictEqual(index, 0) // returns 0 for empty arrays
+  })
+  test('normalizearchivePaths', () => {
+    assert.strictEqual(normalizeArchivePaths('foo'), 'foo')
+    assert.strictEqual(normalizeArchivePaths('/mount/dir/filename'), '/mount/dir/filename')
+    assert.strictEqual(normalizeArchivePaths('c:\\dir\\filename'), 'c:\\dir\\filename')
+    assert.strictEqual(normalizeArchivePaths('c:\\dir\\filename!'), 'c:\\dir\\filename!')
+    assert.strictEqual(normalizeArchivePaths('c:\\dir\\filename!\\path2'), 'c:\\dir\\filename!/path2')
+    assert.strictEqual(normalizeArchivePaths('c:\\dir\\filename!\\path2\\path3'), 'c:\\dir\\filename!/path2/path3')
+    assert.strictEqual(normalizeArchivePaths('c:\\dir\\filename!\\path2\\path3\\'), 'c:\\dir\\filename!/path2/path3/')
+    assert.strictEqual(normalizeArchivePaths('c:\\dir\\filename!\\path2!\\path3'), 'c:\\dir\\filename!/path2!/path3')
   })
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -291,3 +291,24 @@ export function safeStableStringify(obj: any): string | undefined {
   // so we convert bigints to strings with the number + 'n' here
   return stringify(obj, (_, v) => (typeof v === 'bigint' ? v.toString() + 'n' : v))
 }
+
+/**
+ * Normalize the slashes used as internal paths within an archive uri.
+ * Archive Uris have <filepath>!/<internal path>
+ * 
+ * @param fsPath - an fsPath from an Uri. E.g. under windows having \ and not /
+ * @returns a fsPath to the archive filename but the internal part with / instead of \
+ */
+export function normalizeArchivePaths(fsPath: string): string {
+  if (fsPath.includes('!\\')) {
+    const parts = fsPath.split('!\\')
+    if (parts.length<2){
+      return fsPath
+    }
+    const firstPart = parts[0] + '!/'
+    const otherParts = parts.slice(1).join('!/').replaceAll('\\', '/')
+    return firstPart + otherParts
+  } else {
+    return fsPath
+  }
+}


### PR DESCRIPTION
Slash/backslash handling for windows.
Currently adlt expect the path within the archive
always with / and not \\.