### PR TITLE
feat(unzip): add .7z, .bz2, ... to windows version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A more detailed documentation is available here: [Docs](https://mbehr1.github.io
 - Open DLT files (Mac: &#8679;&#8984;P "Open DLT file...", Linux/Win: Ctrl+Shift+P "Open DLT file..." ) command that uses the provided adlt binary and is only limited by your virtual address space. Tested with 20GB DLT file.
   - supports opening multiple files at once
   - supports opening of CAN .asc files (simply choose the .asc file instead of .dlt files during "Open DLT file..." command)
+  - supports opening of archives directly (win/mac: .zip, .7z, .bz2, .gz, .tar.gz, .tar.bz2, others: .zip) incl. multi-volume archives
   - supports all plugins including a 'CAN' plugin.
   - sorts DLT messages automatically by the monotonic timestamp (and first by lifecycles)
   - an adlt binary is provided with the extension and the path to it is available in VS code terminals or via command "New terminal with adlt in path".

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "vscode": "^1.87.0"
       },
       "optionalDependencies": {
-        "node-adlt": "0.58.1"
+        "node-adlt": "0.59.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10469,9 +10469,9 @@
       "optional": true
     },
     "node_modules/node-adlt": {
-      "version": "0.58.1",
-      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.58.1.tgz",
-      "integrity": "sha512-IwkczdB0RF4w/LCIR/qcheU7atOTK4rKEcVUJLLCcU5EJL5ekzkLH6DxNQO4NLgt6R2GNJL88jnWCwHJJIkPGg==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.59.0.tgz",
+      "integrity": "sha512-o/Ma749ayh+yWYMzGqoV9vcYNpLdglwe3WOiDks6ZbO7PxuQPPZqGFkyhyr3H6cvonYUdlOHh3OqHhBopch+ow==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -26221,9 +26221,9 @@
       "optional": true
     },
     "node-adlt": {
-      "version": "0.58.1",
-      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.58.1.tgz",
-      "integrity": "sha512-IwkczdB0RF4w/LCIR/qcheU7atOTK4rKEcVUJLLCcU5EJL5ekzkLH6DxNQO4NLgt6R2GNJL88jnWCwHJJIkPGg==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.59.0.tgz",
+      "integrity": "sha512-o/Ma749ayh+yWYMzGqoV9vcYNpLdglwe3WOiDks6ZbO7PxuQPPZqGFkyhyr3H6cvonYUdlOHh3OqHhBopch+ow==",
       "optional": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1061,7 +1061,7 @@
     "ws": "^8.13.0"
   },
   "optionalDependencies": {
-    "node-adlt": "0.58.1"
+    "node-adlt": "0.59.0"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
Now the windows and the mac-arm version use
libarchive to support .7z, .bz2, .tar.gz, .tar.bz2 archives.