### PR TITLE
feat(report): use dlt-logs-utils v0.2.0 providing tlAll

### DIFF
--- a/media/timeLinesChart.js
+++ b/media/timeLinesChart.js
@@ -122,15 +122,19 @@ colorScale.domain = (a) => {
 };
 
 const segmentTooltipContent = (seg) => {
-    const startTime = seg.timeRange[0];
-    const endTime = seg.timeRange[1];
-    const toolTip = seg?.val.t;
-    if (startTime === endTime) {
-        return `'${seg.group}.${seg.label}' = '<strong>${seg.labelVal}</strong>'${toolTip ? `<br>${toolTip}<br>` : '<br>'}${moment(startTime).format('LTS.SSS [ms]')}`;
-    } else {
-        const durS = (endTime - startTime) / 1000;
-        return `'${seg.group}.${seg.label}' = '<strong>${seg.labelVal}</strong>'${toolTip ? `<br>${toolTip}<br>` : '<br>'}${moment(startTime).format('LTS.SSS [ms]')}-${moment(endTime).format('LTS.SSS [ms]')}<br>duration ${durS.toFixed(3)}s`;
-    }
+  const startTime = seg.timeRange[0]
+  const endTime = seg.timeRange[1]
+  const toolTip = seg?.val.t
+  if (startTime === endTime) {
+    return `'${seg.group}.${seg.label}' = '<strong>${seg.labelVal}</strong>'${toolTip ? `<br>${toolTip}<br>` : '<br>'}${moment(
+      startTime,
+    ).format('LTS.SSS [ms]')}`
+  } else {
+    const durS = (endTime - startTime) / 1000
+    return `'${seg.group}.${seg.label}' = '<strong>${seg.labelVal}</strong>'${toolTip ? `<br>${toolTip}<br>` : '<br>'}${moment(
+      startTime,
+    ).format('LTS.SSS [ms]')}-${moment(endTime).format('LTS.SSS [ms]')}<br>duration ${durS.toFixed(3)}s`
+  }
 };
 
 const handleSegmentClick = (ev) => {

--- a/media/timeSeriesReport.html
+++ b/media/timeSeriesReport.html
@@ -83,6 +83,22 @@
         .timelines-chart .reset-zoom-btn {
             fill: var(--vscode-button-foreground);
         }
+        .tl.tt ul {
+            list-style-type: none;
+            padding: 0;
+        }
+        .tl.tt li {
+            display: flex;
+            align-items: center;
+            margin-bottom: 10px;
+        }
+        .tl.tt .sl {
+            width: 15px;
+            height: 15px;
+            border-radius: 50%;
+            margin-right: 10px;
+            background-color: var(--sc);
+        }
         .brusher .grid-background { /* background for time overview below the swimlanes */
             fill: var(--vscode-editor-background);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "chartjs-adapter-moment": "^1.0.1",
         "chartjs-plugin-annotation": "^2.2.1",
         "chartjs-plugin-zoom": "^2.0.1",
-        "dlt-logs-utils": "0.1.0",
+        "dlt-logs-utils": "0.2.0",
         "fast-xml-parser": "^3.19.0",
         "hammerjs": "^2.0.8",
         "hw-chartjs-plugin-colorschemes": "0.5.4",
@@ -6179,9 +6179,9 @@
       }
     },
     "node_modules/dlt-logs-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dlt-logs-utils/-/dlt-logs-utils-0.1.0.tgz",
-      "integrity": "sha512-XlAolmR4UfDGimvlhzwW0N2xF7g70MibyforFLC76c5sTbgYd49IUSQY67C1wJSEcX3KqxQ5rcSCX7wk8B2Mjg=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dlt-logs-utils/-/dlt-logs-utils-0.2.0.tgz",
+      "integrity": "sha512-aByT16KJKlylHlQVBrN71gAQ+eRm9FSWAXCWkWwZcBxgrdusdlBVH6YwbNPlM2Rwndx09TGp5yaqtLCnukUDMw=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -22972,9 +22972,9 @@
       }
     },
     "dlt-logs-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dlt-logs-utils/-/dlt-logs-utils-0.1.0.tgz",
-      "integrity": "sha512-XlAolmR4UfDGimvlhzwW0N2xF7g70MibyforFLC76c5sTbgYd49IUSQY67C1wJSEcX3KqxQ5rcSCX7wk8B2Mjg=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dlt-logs-utils/-/dlt-logs-utils-0.2.0.tgz",
+      "integrity": "sha512-aByT16KJKlylHlQVBrN71gAQ+eRm9FSWAXCWkWwZcBxgrdusdlBVH6YwbNPlM2Rwndx09TGp5yaqtLCnukUDMw=="
     },
     "doctrine": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1046,7 +1046,7 @@
     "chartjs-adapter-moment": "^1.0.1",
     "chartjs-plugin-annotation": "^2.2.1",
     "chartjs-plugin-zoom": "^2.0.1",
-    "dlt-logs-utils": "0.1.0",
+    "dlt-logs-utils": "0.2.0",
     "fast-xml-parser": "^3.19.0",
     "hammerjs": "^2.0.8",
     "hw-chartjs-plugin-colorschemes": "0.5.4",


### PR DESCRIPTION
Introduce tlAll function that allows to represent timelines for multiple states in a single timeline with an overview inside the tooltip.