### PR TITLE
ci: package win32-arm64 as well

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -13,10 +13,11 @@ jobs:
             platform: win32
             arch: x64
             npm_config_arch: x64
-          # - os: windows-latest
-          #  platform: win32
-          #  arch: arm64
-          #  npm_config_arch: arm
+          - os: windows-latest
+            vsce_target: win32-arm64
+            platform: win32
+            arch: x64_for_arm64 # for now we do use the win build
+            npm_config_arch: x64
           - os: ubuntu-latest
             vsce_target: linux-x64
             platform: linux

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -17,10 +17,9 @@ jobs:
           - os: windows-latest
             vsce_target: win32-x64
             npm_config_arch: x64
-          # - os: windows-latest
-          #  platform: win32
-          #  arch: arm64
-          #  npm_config_arch: arm
+          - os: windows-latest
+            vsce_target: win32-arm64
+            npm_config_arch: x64 # for now we use the win32 build
           - os: ubuntu-latest
             vsce_target: linux-x64
             npm_config_arch: x64
@@ -66,10 +65,10 @@ jobs:
     if: success()
     steps:
       - uses: actions/download-artifact@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
       - run: npx @vscode/vsce publish --packagePath $(find . -iname *.vsix)
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
-      - run: npx @vscode/vsce publish --target win32-arm64 --packagePath $(find . -iname dlt-logs-win32-x64-*.vsix)
         env:
           VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
       - run: echo $(find . -iname *.vsix)

--- a/README.md
+++ b/README.md
@@ -195,13 +195,13 @@ Currently the binaries are included for:
 - macOS, x64, x86_64-apple-darwin
 - macOS, arm64, aarch64-apple-darwin (e.g. M1 Macs)
 - Windows, win32 x64 64bit, x86_64-pc-windows-msvc
-- Windows, win32 ia32 32bit, i686-pc-windows-msvc
+- Windows, win32 arm64 <- includes the binaries for win32-x64 relying on win emulation. (native arm64 binaries in preparation)
 - Linux, x64,  (MUSL), x86_64-unknown-linux-musl
 - Linux, arm64, aarch64-unknown-linux-gnu
 - Alpine, x64, (MUSL), x86_64-unknown-linux-musl
 
 So missing are:
-- Windows, win32-arm64
+- Windows, win32-arm64 (native binaries)
 - Linux, linux-armhf
 - Alpine Linux, alpine-arm64.
 


### PR DESCRIPTION
and use node lts/* for npx vsce.