### PR TITLE
fix(report): provide needed modules for report

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,6 +10,16 @@ esbuild.js
 node_modules
 !node_modules/node-adlt
 !node_modules/@vscode/codicons/dist
+!node_modules/@vscode/webview-ui-toolkit/dist
+!node_modules/moment/min
+!node_modules/chart.js/dist
+!node_modules/chartjs-adapter-moment/dist
+!node_modules/chartjs-plugin-zoom/dist
+!node_modules/chartjs-plugin-annotation/dist
+!node_modules/hw-chartjs-plugin-colorschemes/dist
+!node_modules/hammerjs
+!node_modules/timelines-chart/dist
+!node_modules/w3-css
 tsconfig_test.json
 **/tsconfig.json
 **/vite.config.ts


### PR DESCRIPTION
Have been lost with the change to esbuild.
As they are referenced from some html code esbuild can not detect those. Need to think about how to bundle those properly and reliably from the build itself.