### PR TITLE
feat(sequences): support open as doc/markdown preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -804,6 +804,11 @@
         "command": "dlt-logs.treeItemToClipboard",
         "title": "Export to clipboard",
         "icon": "$(clippy)"
+      },
+      {
+        "command": "dlt-logs.treeItemToDocument",
+        "title": "Export to/open as document",
+        "icon": "$(open-preview)"
       }
     ],
     "menus": {
@@ -913,6 +918,11 @@
         {
           "command": "dlt-logs.treeItemToClipboard",
           "when": "view == dltLifecycleExplorer && viewItem =~ /canCopyToClipboard/",
+          "group": "inline"
+        },
+        {
+          "command": "dlt-logs.treeItemToDocument",
+          "when": "view == dltLifecycleExplorer && viewItem =~ /canTreeItemToDocument/",
           "group": "inline"
         }
       ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -695,6 +695,11 @@ export function activate(context: vscode.ExtensionContext) {
       adltProvider.onTreeNodeCommand('copyToClipboard', args[0])
     }),
   )
+  context.subscriptions.push(
+    vscode.commands.registerCommand('dlt-logs.treeItemToDocument', async (...args: any[]) => {
+      adltProvider.onTreeNodeCommand('treeItemToDocument', args[0])
+    }),
+  )
 
   context.subscriptions.push(
     vscode.commands.registerCommand('dlt-logs.openReport', async (...args: any[]) => {


### PR DESCRIPTION
Add a command for the sequence tree view items to open the result as a markdown document and opening the preview to it as well.