### PR TITLE
feat(search): cmd/ctrl+a/c copies all search results to clipboard

### DIFF
--- a/webviews/search/src/App.css
+++ b/webviews/search/src/App.css
@@ -63,6 +63,9 @@ pre {
     background-color: var(--vscode-inputOption-hoverBackground);
 }
 
+.sitemSelected {
+    background-color: var(--vscode-editor-selectionBackground);
+}
 .sitemFindMatch {
     background-color: var(--vscode-editor-findMatchHighlightBackground);
     outline-style: solid;


### PR DESCRIPTION
As the search window is using a windowed list copying "all" content from there does not really copy all but only the shown/windowed ones.

Removed the default behaviour (context menu and ctrl/cmd+a, ctrl/cmd+c) and replaced by an own implementation that really copies the full result to clipboard. If not all messages are selected (via ctrl/cmd+a) then the default behaviour is kept.