### PR TITLE
fix: ecu lc nodes were showing outdated info / adlt 0.62.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "vscode": "^1.87.0"
       },
       "optionalDependencies": {
-        "node-adlt": "0.61.5"
+        "node-adlt": "0.62.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -13274,9 +13274,9 @@
       "optional": true
     },
     "node_modules/node-adlt": {
-      "version": "0.61.5",
-      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.61.5.tgz",
-      "integrity": "sha512-aAIX8N1QwZDl/hu6B9BOMu+1LSJ/4gNvKa+NEA462ZwUjmXvU4t25wjxp2uIbceG93M5WNMo2+KwO45VAlKjBQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.62.0.tgz",
+      "integrity": "sha512-JglFsAuxR6Wzs2GXxigOAkKnGfQ4AxxMwEyHM6p/VCE4RZ2/qk7b7NFJToDNt6lQa5ZQbT2SegIshPq18e7LpQ==",
       "hasInstallScript": true,
       "license": "CC-BY-NC-SA-4.0",
       "optional": true,
@@ -31257,9 +31257,9 @@
       "optional": true
     },
     "node-adlt": {
-      "version": "0.61.5",
-      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.61.5.tgz",
-      "integrity": "sha512-aAIX8N1QwZDl/hu6B9BOMu+1LSJ/4gNvKa+NEA462ZwUjmXvU4t25wjxp2uIbceG93M5WNMo2+KwO45VAlKjBQ==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/node-adlt/-/node-adlt-0.62.0.tgz",
+      "integrity": "sha512-JglFsAuxR6Wzs2GXxigOAkKnGfQ4AxxMwEyHM6p/VCE4RZ2/qk7b7NFJToDNt6lQa5ZQbT2SegIshPq18e7LpQ==",
       "optional": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1134,7 +1134,7 @@
     "ws": "^8.13.0"
   },
   "optionalDependencies": {
-    "node-adlt": "0.61.5"
+    "node-adlt": "0.62.0"
   },
   "commitlint": {
     "extends": [

--- a/src/adltExport.ts
+++ b/src/adltExport.ts
@@ -171,7 +171,8 @@ export async function exportDlt(
                 if (Array.isArray(v)) {
                   console.log(`lcs onValue(${v.map((v) => v.name).join(',')})`)
                   // now add the lifecycles:
-                  ;(<readonly PickItem[]>v).forEach((pi) => {
+                  const piv: PickItem[] = v as PickItem[]
+                  piv.forEach((pi) => {
                     if (pi.data !== undefined) {
                       exportOptions.lcsToKeep.push(pi.data)
                     }

--- a/src/dltAddEditFilter.ts
+++ b/src/dltAddEditFilter.ts
@@ -230,12 +230,12 @@ export function editFilter(
     }
 
     if ('configTreeNode' in doc) {
-      ;(doc as DltDocument) /* todo! */.configTreeNode.children
-        .forEach((node) => {
-          if (node instanceof ConfigNode) {
-            addConfig(node, '')
-          }
-        })
+      const dDoc: DltDocument = doc as DltDocument
+      dDoc.configTreeNode.children.forEach((node) => {
+        if (node instanceof ConfigNode) {
+          addConfig(node, '')
+        }
+      })
     }
 
     let stepInput = new MultiStepInput(

--- a/src/dltDocument.ts
+++ b/src/dltDocument.ts
@@ -1905,7 +1905,7 @@ export class DltDocument {
         }
         if (showTime) {
           toRet += new Date(msg.receptionTimeInMs).toLocaleTimeString() + ' '
-        } // todo pad to one len?
+        } // todo pad to one len? (pad based on max time 23:59:59?)
         if (showCalculatedTime) {
           let timeC =
             msg.mstp === MSTP.TYPE_CONTROL && msg.mtin === MTIN_CTRL.CONTROL_REQUEST

--- a/src/dltExport.ts
+++ b/src/dltExport.ts
@@ -197,7 +197,8 @@ export async function exportDltOldTS(srcUris: vscode.Uri[], allFilters: DltFilte
       if (Array.isArray(v)) {
         console.log(`lcs onValue(${v.map((v) => v.name).join(',')})`)
         // now add the lifecycles:
-        ;(<readonly PickItem[]>v).forEach((pi) => {
+        const piv: PickItem[] = v as PickItem[]
+        piv.forEach((pi) => {
           if (pi.data !== undefined && pi.data.lcInfo !== undefined) {
             exportOptions.lcsToKeep.push(pi.data.lcInfo)
           }

--- a/src/dltLoadTimeAssistant.ts
+++ b/src/dltLoadTimeAssistant.ts
@@ -135,7 +135,8 @@ export async function loadTimeFilterAssistant(fileUri: vscode.Uri, allFilters: D
       tempEnableLoadTimeFilters = []
       if (Array.isArray(v)) {
         //console.log(` onValue(${v.map(v => v.name).join(',')})`);
-        ;(<readonly PickItem[]>v).forEach((pi) => {
+        const piv: PickItem[] = v as PickItem[]
+        piv.forEach((pi) => {
           if (pi.data !== undefined) {
             tempEnableLoadTimeFilters.push(pi.data)
           }


### PR DESCRIPTION
If the lc infos were updated the tooltip with the sw info and the parent ecuNode with the SW info
were not updated.
Optimized to fire updates only if content changes.

Update adlt to 0.62.0 as well.