### PR TITLE
fix(restquery): inform on subscribe about the active doc

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1460,9 +1460,20 @@ export function activate(context: vscode.ExtensionContext) {
     },
     // restQuery should follow the principles from here: https://jsonapi.org/format/
     restQuery(query: string) {
-      /*console.log(`dlt-logs.restQuery(${query}) called.`); */ return restQuery(context, query)
+      return restQuery(context, query)
     },
     onDidChangeActiveRestQueryDoc(listener: any) {
+      if (_lastActiveQueryDocUri !== undefined) {
+        // we'll inform the listener about the current active doc immediately as the doc might not change for a while
+        setImmediate(() => {
+          log.info(`dlt-logs.onDidChangeActiveRestQueryDoc: calling listener for _lastActiveQueryDocUri=${_lastActiveQueryDocUri}`)
+          try {
+            listener(_lastActiveQueryDocUri)
+          } catch (err) {
+            log.error(`dlt-logs.onDidChangeActiveRestQueryDoc: listener threw error=${err}`)
+          }
+        })
+      }
       return onDidChangeActiveRestQueryDoc(listener)
     },
   }


### PR DESCRIPTION
At startup the active doc might be set before the other extension subscribes.
So on subscribe if a doc is set inform only the new subscriber about that doc.