### PR TITLE
feat(report): add checkbox to show the lc annotation lines

### DIFF
--- a/docs/dlt-logs/docs/reports.md
+++ b/docs/dlt-logs/docs/reports.md
@@ -68,6 +68,11 @@ In general the report covers the timeframe from all [lifecycles](lifecycleDetect
 E.g. in the picture from the example above the first lifecycle starts at 5:41:05pm but the first logs start only at 5:42:29pm. The default view is useful to e.g. understood how the lifecycle was already running before the logs have been captured or exported.
 With the `Toggle lifecycle start` button you can toggle the view to hide/show the timeframe where no logs are available for.
 
+### Show lifecycle annotations
+
+The `LC annotations` checkbox allows you to hide/show the lifecycle horizontal lines that show the start, end, ECU name and lifecycle number.
+The setting is persisted in the extension globalState.
+
 ### Show the current selected time
 
 The report highlights the selected time - i.e. the time that corresponds to the selected line in the DLT file with a vertical green dotted line, e.g. here at 5:42:41 PM and 22ms:

--- a/media/timeSeriesReport.html
+++ b/media/timeSeriesReport.html
@@ -19,6 +19,18 @@
 
     <script>
       const vscode = acquireVsCodeApi() // acquireVsCodeApi can only be invoked once
+      let persistedState = {
+        showLifecycleLines: true,
+      }
+      try{
+        persistedState = {
+          ...persistedState,
+          ...(JSON.parse('${{persistedState}}')||{})
+        }
+      }catch(e){
+        console.warn(`couldn't parse persistedState e=${e}`);
+      }
+      console.log('persistedState=', persistedState)
     </script>
     <style>
       canvas {
@@ -227,6 +239,12 @@
         title="This toggles the display of the detected lifecycle start until the first message. So removing the leftmost empty time of the first lifecycle."
         >Show lifecycle start</vscode-checkbox
       >
+      <vscode-checkbox
+        id="chkboxLifecycleLines" 
+        onclick="toggleLifecycleLines(this)"
+        title="Toggles the display of the lifecycle horizontal lines with info on ecu name and lc number."
+        >LC annotations</vscode-checkbox
+      >
       <div style="flex-grow: 1"></div>
       <vscode-button onclick="resetZoom()">Reset zoom</vscode-button>
       <vscode-button
@@ -378,6 +396,7 @@
 
       window.onload = function () {
         try {
+          document.getElementById('chkboxLifecycleLines').checked = !!persistedState.showLifecycleLines
           //console.error('Chart.defaults=', Chart.defaults);
           Chart.defaults.font = {
             weight: vscodeStyles.getPropertyValue('--vscode-editor-font-weight'),
@@ -501,8 +520,10 @@
           }
           lcAnnotations.push(newAnn)
         }
+        const showLifecycleLines = document.getElementById('chkboxLifecycleLines').checked
         for (let i = 0; i < lcAnnotations.length; ++i) {
           let lcAnnotation = lcAnnotations[i]
+          lcAnnotation.display = showLifecycleLines
           const hadSelectedTime = lcAnnotation.xMin !== null
           if (i < lcInfos.length) {
             let lcInfo = lcInfos[i]
@@ -806,6 +827,21 @@
           vscode.postMessage({ message: `update(${event.data.command}) got err:${err}` })
         }
       })
+
+      window.toggleLifecycleLines = function (checkbox) {
+        console.log('toggleLifecycleLines checkbox ' + checkbox.checked)
+        try{
+          persistedState.showLifecycleLines = checkbox.checked
+          vscode.postMessage({ message: 'persistState', state: JSON.stringify(persistedState) }) 
+          console.log('updated persistedState=', persistedState)
+        }catch(e){
+          console.warn(`toggleLifecycleLines persisting failed with e=${e}`);
+        }
+        for (const lcAnnotation of lcAnnotations) {
+          lcAnnotation.display = checkbox.checked
+        }
+        updateGraphs()
+      }
 
       window.toggleLifecycleStart = function (checkbox) {
         console.log('toggleLifecycleStart checkbox ' + checkbox.checked)

--- a/src/dltReport.ts
+++ b/src/dltReport.ts
@@ -691,6 +691,17 @@ export class DltReport implements vscode.Disposable {
             log.warn(`report.onDidReceiveMessage clicked got err=${err}`, e)
           }
           break
+        case 'persistState':
+          try {
+            log.debug(`report.onDidReceiveMessage persistState=${e.state}`)
+            this.context.globalState.update('dltLogsReportState', JSON.parse(e.state))
+          } catch (err) {
+            log.warn(`report.onDidReceiveMessage persistState got err=${err}`, e)
+          }
+          break
+        default:
+          log.debug(`report.onDidReceiveMessage: message '${e.message}'`, e)
+          break
       }
     })
 
@@ -702,6 +713,12 @@ export class DltReport implements vscode.Disposable {
       htmlStr = htmlStr.replace(/\${{media}}/g, mediaPart)
       const scriptsPart = this.panel.webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'node_modules')).toString()
       htmlStr = htmlStr.replace(/\${{scripts}}/g, scriptsPart)
+
+      // persistence of state:
+      let persistedState: any = {
+        ...(this.context.globalState.get('dltLogsReportState') || {}),
+      }
+      htmlStr = htmlStr.replace(/\${{persistedState}}/g, JSON.stringify(persistedState))
       this.panel.webview.html = htmlStr
     } else {
       vscode.window.showErrorMessage(`couldn't load timeSeriesReport.html`)


### PR DESCRIPTION
Added a new checkbox that allows to hide the lifecycle annotation lines in the report. The setting is persisted in extension globalState.