### PR TITLE
fix: update untrusted workspace settings to restrict adlt binary path

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are provided for the latest released version on `master` branch / released in VS Code marketplace.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | Yes       |
+| older   | No        |
+
+## Reporting a Vulnerability
+
+Please do **not** open public GitHub issues for security vulnerabilities.
+
+Instead, report vulnerabilities privately by emailing:
+
+- <mbehr+dltlogs@mcbehr.de>
+
+Please include as much detail as possible:
+
+- A clear description of the issue and potential impact
+- Steps to reproduce
+- A minimal proof of concept, if available
+- Affected versions, configuration, and environment details
+
+## Response Expectations
+
+- Initial acknowledgment: within 7 days
+- Follow-up after triage: as soon as practical
+- Fix timeline: depends on severity and complexity
+
+If the report is accepted, a fix will be prepared and released. Credit can be provided in release notes if requested.
+
+## Scope
+
+This policy applies to the source code and release artifacts in this repository.

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "virtualWorkspaces": false,
     "untrustedWorkspaces": {
       "supported": "limited",
-      "description": "Filter can contain regex and conv functions and thus need to come from a trusted workspace only.",
+      "description": "Filter can contain regex and conv functions and thus need to come from a trusted workspace only. Adlt binary path only from trusted settings.",
       "restrictedConfigurations": [
+        "dlt-logs.adltPath",
         "dlt-logs.filters",
         "dlt-logs.plugins"
       ]


### PR DESCRIPTION
Use adlt binary path setting only from trusted workspaces.

Thanks to Animesh Roy for reporting!